### PR TITLE
When printing to PGN, disambiguate only as needed

### DIFF
--- a/src/main/scala/format/pgn/Dumper.scala
+++ b/src/main/scala/format/pgn/Dumper.scala
@@ -5,19 +5,44 @@ object Dumper {
 
   def apply(situation: Situation, data: chess.Move, next: Situation): String = {
     import data._
+
     ((promotion, piece.role) match {
-      case _ if castles   => if (orig ?> dest) "O-O-O" else "O-O"
-      case _ if enpassant => orig.file + 'x' + dest.key
+      case _ if castles =>
+        if (orig ?> dest) "O-O-O" else "O-O"
+
+      case _ if enpassant =>
+        orig.file + 'x' + dest.key
+
       case (promotion, Pawn) =>
         captures.fold(orig.file + "x", "") +
           promotion.fold(dest.key)(p => dest.key + "=" + p.pgn)
-      case (_, role) => role.pgn + {
+
+      case (_, role) => {
+        // Check whether there is a need to disambiguate:
+        //   - can a piece of same role move to/capture on the same square?
+        //   - if so, disambiguate, in order or preference, by:
+        //       - file
+        //       - rank
+        //       - both (only happens w/ at least 3 pieces of the same role)
         val candidates = situation.board.pieces collect {
           case (cpos, cpiece) if cpiece == piece && cpos != orig && cpiece.eyes(cpos, dest) => cpos
+        } filter { cpos =>
+          // We know Role ≠ Pawn, so it is fine to always pass None as promotion target
+          situation.move(cpos, dest, None).isSuccess
         }
-        if (candidates.isEmpty) ""
-        else if (candidates exists (_ ?| orig)) orig.file + orig.rank else orig.file
-      } + captures.fold("x", "") + dest.key
+
+        val disambiguation = if (candidates.isEmpty) {
+          ""
+        } else if (!candidates.exists(_ ?| orig)) {
+          orig.file
+        } else if (!candidates.exists(_ ?- orig)) {
+          orig.rank
+        } else {
+          orig.file + orig.rank
+        }
+
+        role.pgn + disambiguation + captures.fold("x", "") + dest.key
+      }
     }) + (if (next.check) if (next.checkMate) "#" else "+" else "")
   }
 

--- a/src/test/scala/format/pgn/DumperTest.scala
+++ b/src/test/scala/format/pgn/DumperTest.scala
@@ -23,6 +23,7 @@ class DumperTest extends ChessTest {
       }
     }
   }
+
   "dump a promotion move" should {
     "without check" in {
       val game = Game("""
@@ -86,6 +87,85 @@ R   K  R
       }
     }
   }
+
+  "ambiguous moves" should {
+    "ambiguous file only" in {
+      val game = Game("""
+k
+
+
+
+
+
+P   K  P
+R      R
+""")
+      game.playMoves(H1 -> B1) map (_.pgnMoves) must beSuccess.like {
+        case ms => ms must_== List("Rhb1")
+      }
+    }
+    "ambiguous rank only" in {
+      val game = Game("""
+k
+
+
+ N
+
+
+    K  P
+ N
+""")
+      game.playMoves(B5 -> C3) map (_.pgnMoves) must beSuccess.like {
+        case ms => ms must_== List("N5c3")
+      }
+    }
+    "ambiguous file and rank" in {
+      val game = Game("""
+
+
+  QQ
+  Q
+
+
+    K
+k
+""")
+      game.playMoves(C6 -> D5) map (_.pgnMoves) must beSuccess.like {
+        case ms => ms must_== List("Qc6d5")
+      }
+    }
+    "unambiguous file" in {
+      val game = Game("""
+k
+
+
+
+
+
+P      P
+R   K  R
+""")
+      game.playMoves(H1 -> F1) map (_.pgnMoves) must beSuccess.like {
+        case ms => ms must_== List("Rf1")
+      }
+    }
+    "unambiguous rank" in {
+      val game = Game("""
+k
+
+   KRq
+
+    R
+
+
+
+""")
+      game.playMoves(E4 -> E5) map (_.pgnMoves) must beSuccess.like {
+        case ms => ms must_== List("Re5")
+      }
+    }
+  }
+
   "chess960" should {
     "castle queenside as white" in {
       Game(makeBoard("""


### PR DESCRIPTION
Update to PGN pretty-printer: updates disambiguation information only as needed.

A potential failure point is the interaction with, e.g. pgn4web?
