### PR TITLE
Fix for broken win condition in 3 checks variant

### DIFF
--- a/src/main/scala/Variant.scala
+++ b/src/main/scala/Variant.scala
@@ -165,6 +165,9 @@ object Variant {
       val checks = situation.board.history.checkCount
       situation.color.fold(checks.white, checks.black) >= 3
     }
+
+    override def winner(situation: Situation) = if (specialEnd(situation)) Some(!situation.color) else None
+
   }
 
   case object Antichess extends Variant(

--- a/src/test/scala/VariantTest.scala
+++ b/src/test/scala/VariantTest.scala
@@ -76,6 +76,11 @@ K  r
           E2 -> E4, E7 -> E6, D2 -> D4, F8 -> B4, C2 -> C3,
           B4 -> C3, B1 -> C3, D8 -> H4, A2 -> A3, H4 -> F2).toOption.get
         game.situation.end must beTrue
+
+        game.situation.winner must beSome.like{
+          case color =>
+            color == Black
+        }
       }
     }
   }


### PR DESCRIPTION
If you point the lila submodule to master after this merge, it should fix the bug.
