### PR TITLE
Finalise move on creation

### DIFF
--- a/src/main/scala/Move.scala
+++ b/src/main/scala/Move.scala
@@ -20,7 +20,6 @@ case class Move(
   def withHistory(h: History) = copy(after = after withHistory h)
 
   def finalizeAfter: Board = {
-    val newBoard = {
       after updateHistory { h1 =>
         // last move and position hashes
         val h2 = h1.copy(
@@ -49,12 +48,9 @@ case class Move(
           if h3 canCastle !color on side
         } yield h3.withoutCastle(!color, side)) | h3
       }
-    }
-
-    val move = this.copy(after = newBoard)
-
-    before.variant finalizeMove(move)
   }
+
+  def applyVariantEffect : Move = before.variant addVariantEffect this
 
   def afterWithLastMove = after.copy(
     history = after.history.copy(lastMove = Some(orig, dest)))

--- a/src/main/scala/Replay.scala
+++ b/src/main/scala/Replay.scala
@@ -7,7 +7,7 @@ case class Replay(setup: Game, moves: List[Move], state: Game) {
   lazy val chronoMoves = moves.reverse
 
   def addMove(move: Move) = copy(
-    moves = move :: moves,
+    moves = move.applyVariantEffect :: moves,
     state = state(move))
 
   def moveAtPly(ply: Int): Option[Move] = chronoMoves lift (ply - 1)

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -9,6 +9,8 @@ case object Atomic extends Variant(
   title = "Nuke your opponent's king to win."
 ) {
 
+  override def hasMoveEffects = true
+
   /** Moves which threaten to explode the opponent's king without exploding the player's own king */
   private def kingThreateningMoves(situation: Situation): Map[Pos, List[Move]] = {
 
@@ -58,15 +60,10 @@ case object Atomic extends Variant(
     mergeMap(maps){case (v1, v2) => v1 ++ v2}
   }
 
-  override def move(situation: Situation, from: Pos, to: Pos, promotion: Option[PromotableRole]) = for {
-    m1 <- super.move(situation, from, to, promotion)
-    m2 <- explodeSurroundingPieces(m1).success
-  } yield m2
-
   /** If the move captures, we explode the surrounding pieces. Otherwise, nothing explodes. */
   private def explodeSurroundingPieces(move: Move): Move = {
-    if (!move.captures) move
-    else {
+    if (move.captures)
+    {
       val surroundingPositions = move.dest.surroundingPositions
       val afterBoard = move.after
       val destination = move.dest
@@ -81,10 +78,10 @@ case object Atomic extends Variant(
       val newBoard = afterBoard withPieces afterExplosions
       move withAfter newBoard
     }
-
+    else move
   }
 
-  override def finalizeMove(move: Move) : Board = explodeSurroundingPieces(move).after
+  override def addVariantEffect(move: Move) : Move = explodeSurroundingPieces(move)
 
   /**
    * Since a king may walk into the path of another king, it is more difficult to win when your opponent only has a

--- a/src/main/scala/variant/Threecheck.scala
+++ b/src/main/scala/variant/Threecheck.scala
@@ -8,8 +8,14 @@ case object ThreeCheck extends Variant(
   shortName = "3+",
   title = "Check your opponent 3 times to win the game") {
 
-  override def finalizeMove(move: Move) = move.after updateHistory {
-    _.withCheck(Color.White, move.after.checkWhite).withCheck(Color.Black, move.after.checkBlack)
+  override def hasMoveEffects = true
+
+  override def addVariantEffect(move: Move) : Move = {
+    val board = move.after updateHistory {
+      _.withCheck(Color.White, move.after.checkWhite).withCheck(Color.Black, move.after.checkBlack)
+    }
+
+    move.copy(after = board)
   }
 
   override def specialEnd(situation: Situation) = situation.check && {

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -60,7 +60,12 @@ abstract class Variant(
 
   def drawsOnInsufficientMaterial = true
 
-  def finalizeMove(move: Move): Board = move.after
+  // Some variants have an extra effect on the board on a move. For example, in Atomic, some
+  // pieces surrounding a capture explode
+  def hasMoveEffects = false
+
+  /** Applies a variant specific effect to the move. */
+  def addVariantEffect(move: Move): Move = move
 
   // Some variants, such as atomic chess, give different properties to pieces by replacing them with
   // different piece objects

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -307,6 +307,29 @@ class AtomicVariantTest extends ChessTest {
       }
     }
 
+    "It must be possible to remove yourself from check by exploding a piece next to the piece threatening the king" in {
+      val position = "5k1r/p1ppq1pp/5p2/1B6/1b3P2/2P5/PP4PP/RNB1K2R w KQ - 0 12"
+      val game = fenToGame(position,Atomic)
+
+      val successGame = game flatMap (_.playMoves( (Pos.B5, Pos.D7) ))
+
+      successGame must beSuccess.like {
+        case game =>
+          game.situation.check must beFalse
+      }
+    }
+
+    "It should not be possible to explode a piece, exploding a piece next to it which would result in a check" in {
+      val position = "r1b1k2r/pp1pBppp/2p1p2n/q3P3/B2P4/2N2Q2/PPn2PPP/R3K1NR w KQkq - 9 11"
+      val game = fenToGame(position, Atomic)
+
+      val failureGame = game flatMap (_.playMoves( (Pos.A4, Pos.C2) ))
+
+      failureGame must beFailure.like {
+        case failure => failure mustEqual scalaz.NonEmptyList("Piece on a4 cannot move to c2")
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
Applying variant effects to moves as they are calculated so that we can factor the effect (for example, a piece next to a piece blocking check in Atomic chess) into deciding whether a king is endangered by a move or not.

Submitting as a pull request in case there are any situations I haven't considered where a move is constructed and needs to be finalised. I think (although I'm not sure) Replay.scala covers takebacks.