### PR TITLE
adjust pawns on promotion rank validation for Horde chess

### DIFF
--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -36,7 +36,7 @@ case object Horde extends Variant(
   }
 
   override def valid(board: Board, strict: Boolean) =
-    board.kingPosOf(White).isEmpty && validSide(board, strict)(Black)
+    board.kingPosOf(White).isEmpty && validSide(board, strict)(Black) && !pawnsOnPromotionRank(board, White)
 
   /** The game has a special end condition when white manages to capture all of black's pawns */
   override def specialEnd(situation: Situation) =

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -104,14 +104,19 @@ abstract class Variant(
    */
   def finalizeBoard(board: Board): Board = board
 
+  protected def pawnsOnPromotionRank(board: Board, color: Color) = {
+    val promotionRank = if (color == White) 8 else 1
+    board.pieces.exists {
+      case (pos, Piece(c, r)) if c == color && r == Pawn && pos.y == promotionRank => true
+      case _ => false
+    }
+  }
+
   protected def validSide(board: Board, strict: Boolean)(color: Color) = {
     val roles = board rolesOf color
     roles.count(_ == King) == 1 &&
       (!strict || { roles.count(_ == Pawn) <= 8 && roles.size <= 16 }) &&
-      board.pieces.forall {
-        case (pos, Piece(c, r)) if c == color && r == Pawn && (pos.y == 1 || pos.y == 8) => false
-        case _ => true
-      }
+      !pawnsOnPromotionRank(board, color)
   }
 
   def valid(board: Board, strict: Boolean) = Color.all forall validSide(board, strict)_


### PR DESCRIPTION
This is no longer a security issue or bug for lichess, since you can not setup positions for Horde chess. Anyway, two improvements related to Horde chess:

* It's not a problem to allow pawns on the backrank. Only the promotion rank of the relative side is an issue.
* We should also validate incorrect Horde chess starting positions.