### PR TITLE
validate enpassant squares

### DIFF
--- a/src/main/scala/format/Forsyth.scala
+++ b/src/main/scala/format/Forsyth.scala
@@ -48,10 +48,17 @@ object Forsyth {
     <<(fixedSource) map { situation =>
       val splitted = fixedSource split ' '
       val history = splitted lift 2 map { castles =>
+        val fifthRank = if (situation.color == White) 5 else 4
+        val sixthRank = if (situation.color == White) 6 else 3
+        val seventhRank = if (situation.color == White) 7 else 2
         val lastMove = splitted lift 3 flatMap Pos.posAt match {
-          case Some(pos) if pos.y == 3 => Some(s"${pos.file}2${pos.file}4")
-          case Some(pos) if pos.y == 6 => Some(s"${pos.file}7${pos.file}5")
-          case _                       => None
+          case Some(pos) if pos.y == sixthRank
+            && Pos.posAt(pos.x, fifthRank).flatMap(situation.board.apply).contains(Piece(!situation.color, Pawn))
+            && Pos.posAt(pos.x, sixthRank).flatMap(situation.board.apply).isEmpty
+            && Pos.posAt(pos.x, seventhRank).flatMap(situation.board.apply).isEmpty =>
+              Some(s"${pos.file}${seventhRank}${pos.file}${fifthRank}")
+          case _ =>
+            None
         }
         History.make(lastMove, castles)
       }

--- a/src/test/scala/format/ForsythTest.scala
+++ b/src/test/scala/format/ForsythTest.scala
@@ -131,6 +131,16 @@ class ForsythTest extends ChessTest {
           case s => s.situation.board.history.lastMove must_== Some(Pos.F7, Pos.F5)
         }
       }
+      "last move (for en passant in Pretrov's defense)" in {
+        f <<< "rnbqkb1r/ppp2ppp/8/3pP3/3Qn3/5N2/PPP2PPP/RNB1KB1R w KQkq d6 0 6" must beSome.like {
+          case s => s.situation.board.history.lastMove must_== Some(Pos.D7, Pos.D5)
+        }
+      }
+      "last move (for en passant with black to move)" in {
+        f <<< "4k3/8/8/8/4pP2/8/2K5/8 b - f3 0 1" must beSome.like {
+          case s => s.situation.board.history.lastMove must_== Some(Pos.F2, Pos.F4)
+        }
+      }
     }
     "with history" in {
       "starting" in {
@@ -193,6 +203,28 @@ class ForsythTest extends ChessTest {
       val fen = "1nbqkbn1/pppppppp/8/8/8/R6R/PPPPPPPP/1NBQKBN1 w KQkq - 0 1"
       val fix = "1nbqkbn1/pppppppp/8/8/8/R6R/PPPPPPPP/1NBQKBN1 w - - 0 1"
       f fixCastles fen must beSome(fix)
+    }
+  }
+  "ignore impossible en passant squares" should {
+    "with queen instead of pawn" in {
+      f <<< "8/4k3/8/6K1/1pp5/2q5/1P6/8 w - c3 0 1" must beSome.like {
+        case s => s.situation.board.history.lastMove isEmpty
+      }
+    }
+    "with no pawn" in {
+      f <<< "8/8/8/5k2/5p2/8/5K2/8 b - g3 0 1" must beSome.like {
+        case s => s.situation.board.history.lastMove isEmpty
+      }
+    }
+    "with non empty en passant squares" should {
+      f <<< "8/8/8/5k2/5pP1/8/6K1/8 b - g3 0 1" must beSome.like {
+        case s => s.situation.board.history.lastMove isEmpty
+      }
+    }
+    "with wrong side to move" should {
+      f <<< "8/8/8/5k2/5pP1/8/1K6/8 w - g3 0 1" must beSome.like {
+        case s => s.situation.board.history.lastMove isEmpty
+      }
     }
   }
 }


### PR DESCRIPTION
We need to verify that:
* the en-passant square is on rank 3, if black is to move
* the en-passant square is on rank 6, if white is to move
* there is a pawn of the opposite color on the fifth rank and the correct en-passant file (from our pov)
* the square on the seventh and sixth rank was left behind empty

Please review carefully. Also, it is very likely that there is more elegant Scala for this. I'd like to learn ;)