### PR TITLE
Apply insufficient winning material when flagging to atomic and horde variants

### DIFF
--- a/src/main/scala/Actor.scala
+++ b/src/main/scala/Actor.scala
@@ -200,7 +200,7 @@ object Actor {
    * Determines the position one ahead of a pawn based on the color of the piece.
    * White pawns move up and black pawns move down.
    */
-  def posAheadOfPawn(pos: Pos, color: Color) = pawnDirOf(color)(pos)
+  def posAheadOfPawn(pos: Pos, color: Color): Option[Pos] = pawnDirOf(color)(pos)
 
   /**
    * Determines the squares that a pawn attacks based on the colour of the pawn.

--- a/src/main/scala/Actor.scala
+++ b/src/main/scala/Actor.scala
@@ -194,5 +194,19 @@ object Actor {
   def longRangeThreatens(board: Board, p: Pos, dir: Direction, to: Pos): Boolean =
     board.variant.longRangeThreatens(board, p, dir, to)
 
-  private def pawnDirOf(color: Color): Direction = if (color.white) _.up else _.down
+  def pawnDirOf(color: Color): Direction = if (color.white) _.up else _.down
+
+  /**
+   * Determines the position one ahead of a pawn based on the color of the piece.
+   * White pawns move up and black pawns move down.
+   */
+  def posAheadOfPawn(pos: Pos, color: Color) = pawnDirOf(color)(pos)
+
+  /**
+   * Determines the squares that a pawn attacks based on the colour of the pawn.
+   */
+  def pawnAttacks(pos: Pos, color : Color) : List[Pos] = {
+    if (color.white) List(pos.upLeft, pos.upRight)
+    else List(pos.downLeft, pos.downRight)
+  }.flatten
 }

--- a/src/main/scala/Board.scala
+++ b/src/main/scala/Board.scala
@@ -113,7 +113,7 @@ case class Board(
   def count(c: Color): Int = pieces.values count (_.color == c)
 
   def autoDraw: Boolean = history.fiftyMoves || {
-    variant.drawsOnInsufficientMaterial && InsufficientMatingMaterial(this)
+    variant.insufficientWinningMaterial(this)
   }
 
   def situationOf(color: Color) = Situation(this, color)

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -33,6 +33,11 @@ object InsufficientMatingMaterial {
     }
   }
 
+  // A pawn is immobile if it is blocked by an opponent pawn (not a bishop)
+  def pawnImmobile(pawn: Actor, board: Board) = pawn.moves.isEmpty && {
+      val blockingPosition = Actor.posAheadOfPawn(pawn.pos, pawn.piece.color)
+      blockingPosition.flatMap(pos => board.actorAt(pos)).exists(act => act.piece.is(Pawn))
+    }
   /*
    * Determines whether a board position is an automatic draw due to neither player
    * being able to mate the other as informed by the traditional chess rules.

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -1,7 +1,11 @@
 package chess
 
-// http://www.e4ec.org/immr.html
-
+/**
+ * Utility methods for helping to determine whether a situation is a draw or a draw
+ * on a player flagging.
+ *
+ * See http://www.e4ec.org/immr.html
+ */
 object InsufficientMatingMaterial {
 
   def nonKingPieces(board: Board) = board.pieces.filter(_._2.role != King).toList
@@ -29,6 +33,11 @@ object InsufficientMatingMaterial {
     }
   }
 
+  /*
+   * Determines whether a board position is an automatic draw due to neither player
+   * being able to mate the other as informed by the traditional chess rules.
+   *
+   */
   def apply(board: Board) = {
 
     lazy val notKingPieces = nonKingPieces(board)
@@ -45,8 +54,8 @@ object InsufficientMatingMaterial {
   }
 
   def apply(board: Board, color: Color) =
-    board rolesOf color filter (King !=) match {
-      case Nil | List(Knight) | List(Bishop) => true
-      case _                                 => false
-    }
+     board rolesOf color filter (King !=) match {
+        case Nil | List(Knight) | List(Bishop) => true
+        case _                                 => false
+  }
 }

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -54,8 +54,8 @@ object InsufficientMatingMaterial {
   }
 
   def apply(board: Board, color: Color) =
-     board rolesOf color filter (King !=) match {
-        case Nil | List(Knight) | List(Bishop) => true
-        case _                                 => false
+    board rolesOf color filter (King !=) match {
+       case Nil | List(Knight) | List(Bishop) => true
+       case _                                 => false
   }
 }

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -33,10 +33,12 @@ object InsufficientMatingMaterial {
     }
   }
 
-  // A pawn is immobile if it is blocked by an opponent pawn (not a bishop)
-  def pawnImmobile(pawn: Actor, board: Board) = pawn.moves.isEmpty && {
+  /*
+   * Returns true if a pawn cannot progress forward because it is blocked by a pawn
+   */
+  def pawnBlockedByPawn(pawn: Actor, board: Board) = pawn.moves.isEmpty && {
       val blockingPosition = Actor.posAheadOfPawn(pawn.pos, pawn.piece.color)
-      blockingPosition.flatMap(pos => board.actorAt(pos)).exists(act => act.piece.is(Pawn))
+      blockingPosition.flatMap(board.actorAt(_)).exists(_.piece.is(Pawn))
     }
   /*
    * Determines whether a board position is an automatic draw due to neither player

--- a/src/main/scala/Situation.scala
+++ b/src/main/scala/Situation.scala
@@ -24,9 +24,7 @@ case class Situation(board: Board, color: Color) {
 
   def variantEnd = board.variant specialEnd this
 
-  def variantDraw = board.variant specialDraw this
-
-  def end: Boolean = checkMate || staleMate || autoDraw || variantEnd || variantDraw
+  def end: Boolean = checkMate || staleMate || autoDraw || variantEnd
 
   def winner : Option[Color] = board.variant.winner(this)
 
@@ -37,7 +35,7 @@ case class Situation(board: Board, color: Color) {
     if (checkMate) Status.Mate.some
     else if (variantEnd) Status.VariantEnd.some
     else if (staleMate) Status.Stalemate.some
-    else if (autoDraw || variantDraw) Status.Draw.some
+    else if (autoDraw) Status.Draw.some
     else none
 
   def move(from: Pos, to: Pos, promotion: Option[PromotableRole]): Valid[Move] =

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -75,7 +75,7 @@ case object Antichess extends Variant(
     // The pawn cannot attack a bishop or be attacked by a bishop
     val cannotAttackBishop = Actor.pawnAttacks(pawn.pos, pawn.piece.color).find(_.color == oppositeBishopColor).isEmpty
 
-    InsufficientMatingMaterial.pawnImmobile(pawn, board) && cannotAttackBishop
+    InsufficientMatingMaterial.pawnBlockedByPawn(pawn, board) && cannotAttackBishop
   }
 
   // In this game variant, a king is a valid promotion

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -32,7 +32,7 @@ case object Antichess extends Variant(
   }
 
   // In antichess, there is no checkmate condition therefore a player may only draw either by agreement
-  // or blockade (see specialDraw).
+  // , blockade or stalemate - a player always has sufficient material to win otherwise
   override def insufficientWinningMaterial(situation: Situation, color: Color) = false
 
   // No player can win if the only remaining pieces are opposing bishops on different coloured

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -31,14 +31,15 @@ case object Antichess extends Variant(
     situation.board.actorsOf(situation.color).isEmpty || situation.moves.isEmpty
   }
 
-  // This mode has no checkmates
-  override def drawsOnInsufficientMaterial = false
+  // In antichess, there is no checkmate condition therefore a player may only draw either by agreement
+  // or blockade (see specialDraw).
+  override def insufficientWinningMaterial(situation: Situation, color: Color) = false
 
   // No player can win if the only remaining pieces are opposing bishops on different coloured
   // diagonals. There may be pawns that are incapable of moving and do not attack the right color
   // of square to allow the player to force their opponent to capture their bishop, also resulting in a draw
-  override def specialDraw(situation: Situation) = {
-    val actors = situation.board.actors
+  override def insufficientWinningMaterial (board: Board) = {
+    val actors = board.actors
 
     // Exit early if we are not in a situation with only bishops and pawns
     val bishopsAndPawns = actors.forall(act => act._2.piece.is(Bishop) || act._2.piece.is(Pawn)) &&

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -72,16 +72,10 @@ case object Antichess extends Variant(
   }
 
   private def pawnNotAttackable(pawn: Actor, oppositeBishopColor: Color, board: Board) = {
-    // A pawn is immobile if it is blocked by an opponent pawn (not a bishop)
-    val pawnImmobile = pawn.moves.isEmpty && {
-      val blockingPosition = Actor.posAheadOfPawn(pawn.pos, pawn.piece.color)
-      blockingPosition.flatMap(pos => board.actorAt(pos)).exists(act => act.piece.is(Pawn))
-    }
-
     // The pawn cannot attack a bishop or be attacked by a bishop
     val cannotAttackBishop = Actor.pawnAttacks(pawn.pos, pawn.piece.color).find(_.color == oppositeBishopColor).isEmpty
 
-    pawnImmobile && cannotAttackBishop
+    InsufficientMatingMaterial.pawnImmobile(pawn, board) && cannotAttackBishop
   }
 
   // In this game variant, a king is a valid promotion

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -86,8 +86,11 @@ case object Atomic extends Variant(
     }
   }
 
-  // Bishops on opposite coloured squares can never capture each other to cause a king to explode and a traditional
-  // mate would be not be very likely
+  /*
+   * Bishops on opposite coloured squares can never capture each other to cause a king to explode and a traditional
+   * mate would be not be very likely. Additionally, a player can only mate another player with sufficient material.
+   * We also look out for closed positions (pawns that cannot move and kings which cannot capture them.)
+   */
   override def insufficientWinningMaterial(board: Board) = {
     InsufficientMatingMaterial.bishopsOnDifferentColor(board) || insufficientAtomicWinningMaterial(board) || atomicClosedPosition(board)
   }

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -86,15 +86,22 @@ case object Atomic extends Variant(
     }
   }
 
-  override def specialDraw(situation: Situation) = {
-    // Bishops on opposite coloured squares can never capture each other to cause a king to explode and a traditional
-    // mate would be not be
-    val board = situation.board
+  // Bishops on opposite coloured squares can never capture each other to cause a king to explode and a traditional
+  // mate would be not be
+  override def insufficientWinningMaterial(board: Board) = {
     InsufficientMatingMaterial.bishopsOnDifferentColor(board) || insufficientAtomicWinningMaterial(board)
   }
 
-  // On insufficient mating material, a win may still be commonly achieved by exploding a piece next to a king
-  override def drawsOnInsufficientMaterial = false
+  /**
+   * In atomic chess, it is possible to win with a single knight, bishop, etc, by exploding
+   * a piece in the opponent's king's proximity. On the other hand, a king alone or a king with
+   * immobile pawns is not sufficient material to win with.
+   */
+  override def insufficientWinningMaterial(situation: Situation, color: Color) = {
+    situation.board rolesOf color match {
+      case List(King) => true
+    }
+  }
 
   /** Atomic chess has a special end where a king has been killed by exploding with an adjacent captured piece */
   override def specialEnd(situation: Situation) = situation.board.kingPos.size != 2

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -87,9 +87,13 @@ case object Atomic extends Variant(
   }
 
   // Bishops on opposite coloured squares can never capture each other to cause a king to explode and a traditional
-  // mate would be not be
+  // mate would be not be very likely
   override def insufficientWinningMaterial(board: Board) = {
     InsufficientMatingMaterial.bishopsOnDifferentColor(board) || insufficientAtomicWinningMaterial(board)
+  }
+
+  private def atomicClosedPosition(board: Board) = {
+    board.actors.values.forall(actor => actor.piece.is(Pawn) && actor.moves.isEmpty)
   }
 
   /**

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -89,11 +89,15 @@ case object Atomic extends Variant(
   // Bishops on opposite coloured squares can never capture each other to cause a king to explode and a traditional
   // mate would be not be very likely
   override def insufficientWinningMaterial(board: Board) = {
-    InsufficientMatingMaterial.bishopsOnDifferentColor(board) || insufficientAtomicWinningMaterial(board)
+    InsufficientMatingMaterial.bishopsOnDifferentColor(board) || insufficientAtomicWinningMaterial(board) || atomicClosedPosition(board)
   }
 
+  /**
+   * Since a king cannot capture, K + P vs K + P where none of the pawns can move is an automatic draw
+   */
   private def atomicClosedPosition(board: Board) = {
-    board.actors.values.forall(actor => actor.piece.is(Pawn) && actor.moves.isEmpty)
+    board.actors.values.forall(actor => (actor.piece.is(Pawn) && actor.moves.isEmpty
+      && InsufficientMatingMaterial.pawnImmobile(actor, board)) || actor.piece.is(King))
   }
 
   /**

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -97,7 +97,7 @@ case object Atomic extends Variant(
    */
   private def atomicClosedPosition(board: Board) = {
     board.actors.values.forall(actor => (actor.piece.is(Pawn) && actor.moves.isEmpty
-      && InsufficientMatingMaterial.pawnImmobile(actor, board)) || actor.piece.is(King))
+      && InsufficientMatingMaterial.pawnBlockedByPawn(actor, board)) || actor.piece.is(King))
   }
 
   /**

--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -42,8 +42,8 @@ case object Horde extends Variant(
   override def specialEnd(situation: Situation) =
     situation.board.piecesOf(White).isEmpty
 
-  // is that right?
-  override val drawsOnInsufficientMaterial = false
+  // TODO: There are some situations where there is insufficient winning material: https://github.com/ornicar/lila/issues/773
+  override def insufficientWinningMaterial(situation: Situation, color: Color) = false
 
   override def isUnmovedPawn(color: Color, pos: Pos) = {
     color == White && (pos.y == 1 || pos.y == 2)

--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -42,8 +42,14 @@ case object Horde extends Variant(
   override def specialEnd(situation: Situation) =
     situation.board.piecesOf(White).isEmpty
 
-  // TODO: There are some situations where there is insufficient winning material: https://github.com/ornicar/lila/issues/773
-  override def insufficientWinningMaterial(situation: Situation, color: Color) = false
+  /**
+   * In horde chess, white cannot win on * V K or [BN]{2} v K or just one piece since they don't have a king
+   * for support.
+   */
+  override def insufficientWinningMaterial(situation: Situation, color: Color) = {
+    color == Color.white && situation.board.pieces.size == 1 ||
+      situation.board.pieces.size == 2 && situation.board.piecesOf(Color.white).forall(_._2.isMinor)
+  }
 
   override def isUnmovedPawn(color: Color, pos: Pos) = {
     color == White && (pos.y == 1 || pos.y == 2)

--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -47,8 +47,9 @@ case object Horde extends Variant(
    * for support.
    */
   override def insufficientWinningMaterial(situation: Situation, color: Color) = {
-    color == Color.white && situation.board.pieces.size == 1 ||
-      situation.board.pieces.size == 2 && situation.board.piecesOf(Color.white).forall(_._2.isMinor)
+    color == Color.white && situation.board.piecesOf(Color.white).size == 1 ||
+      situation.board.piecesOf(Color.white).size == 2 &&
+        situation.board.piecesOf(Color.white).forall(_._2.isMinor)
   }
 
   override def isUnmovedPawn(color: Color, pos: Pos) = {

--- a/src/main/scala/variant/KingOfTheHill.scala
+++ b/src/main/scala/variant/KingOfTheHill.scala
@@ -14,6 +14,11 @@ case object KingOfTheHill extends Variant(
   override def specialEnd(situation: Situation) =
     situation.board.kingPosOf(!situation.color) exists center.contains
 
+  /**
+   * You only need a king to be able to win in this variant
+   */
+  override def insufficientWinningMaterial(situation: Situation, color: Color) = false
+
   override def insufficientWinningMaterial(board: Board) = false
 }
 

--- a/src/main/scala/variant/KingOfTheHill.scala
+++ b/src/main/scala/variant/KingOfTheHill.scala
@@ -14,6 +14,6 @@ case object KingOfTheHill extends Variant(
   override def specialEnd(situation: Situation) =
     situation.board.kingPosOf(!situation.color) exists center.contains
 
-  override def drawsOnInsufficientMaterial = false
+  override def insufficientWinningMaterial(board: Board) = false
 }
 

--- a/src/main/scala/variant/Threecheck.scala
+++ b/src/main/scala/variant/Threecheck.scala
@@ -18,6 +18,15 @@ case object ThreeCheck extends Variant(
     situation.color.fold(checks.white, checks.black) >= 3
   }
 
+  /**
+   * It's not possible to check or checkmate the opponent with only a king
+   */
+  override def insufficientWinningMaterial(situation: Situation, color: Color) = {
+    situation.board.piecesOf(color) match {
+      case List(King) => true
+    }
+  }
+
   // When there is insufficient mating material, there is still potential to win by checking the opponent 3 times
   // by the variant ending. However, no players can check if there are only kings remaining
   override def insufficientWinningMaterial(board: Board) = board.actors.forall(_._2.piece is King)

--- a/src/main/scala/variant/Threecheck.scala
+++ b/src/main/scala/variant/Threecheck.scala
@@ -19,12 +19,6 @@ case object ThreeCheck extends Variant(
   }
 
   // When there is insufficient mating material, there is still potential to win by checking the opponent 3 times
-  // by the variant ending
-  override def drawsOnInsufficientMaterial = false
-
-  // Although we do not draw on a traditional 'insufficient mating material', we do draw if only kings remain
-  override def specialDraw(situation: Situation) = {
-    situation.board.actors.forall(_._2.piece is King)
-  }
-
+  // by the variant ending. However, no players can check if there are only kings remaining
+  override def insufficientWinningMaterial(board: Board) = board.actors.forall(_._2.piece is King)
 }

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -94,7 +94,7 @@ abstract class Variant(
   def insufficientWinningMaterial(board: Board) = InsufficientMatingMaterial(board)
 
   /**
-   * Returns true if the player of the given colour has sufficient material to win.
+   * Returns true if the player of the given colour has insufficient material to win.
    * This can be used to determine whether a player losing on time against a player
    * who doesn't have enough material to win should draw instead.
    */

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -3,6 +3,7 @@ package variant
 
 import Pos.posAt
 import scalaz.Validation.FlatMap._
+import InsufficientMatingMaterial.apply
 
 abstract class Variant(
     val id: Int,
@@ -87,7 +88,17 @@ abstract class Variant(
 
   def specialDraw(situation: Situation) = false
 
-  def drawsOnInsufficientMaterial = true
+  /**
+   * Returns true if neither player can win
+   */
+  def insufficientWinningMaterial(board: Board) = InsufficientMatingMaterial(board)
+
+  /**
+   * Returns true if the player of the given colour has sufficient material to win.
+   * This can be used to determine whether a player losing on time against a player
+   * who doesn't have enough material to win should draw instead.
+   */
+  def insufficientWinningMaterial(situation: Situation, color: Color) = InsufficientMatingMaterial(situation.board, color)
 
   // Some variants have an extra effect on the board on a move. For example, in Atomic, some
   // pieces surrounding a capture explode

--- a/src/test/scala/AntichessVariantTest.scala
+++ b/src/test/scala/AntichessVariantTest.scala
@@ -170,7 +170,7 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       newGame must beSuccess.like {
         case drawnGame =>
           drawnGame.situation.end must beTrue
-          drawnGame.situation.variantDraw must beTrue
+          drawnGame.situation.autoDraw must beTrue
           drawnGame.situation.winner must beNone
           drawnGame.situation.status must beSome.like {
             case status => status == Status.Draw
@@ -187,7 +187,7 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       newGame must beSuccess.like {
         case drawnGame =>
           drawnGame.situation.end must beTrue
-          drawnGame.situation.variantDraw must beTrue
+          drawnGame.situation.autoDraw must beTrue
           drawnGame.situation.winner must beNone
           drawnGame.situation.status must beSome.like {
             case status => status == Status.Draw
@@ -205,7 +205,7 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       newGame must beSuccess.like {
         case nonDrawnGame =>
           nonDrawnGame.situation.end must beFalse
-          nonDrawnGame.situation.variantDraw must beFalse
+          nonDrawnGame.situation.autoDraw must beFalse
           nonDrawnGame.situation.winner must beNone
       }
     }
@@ -219,7 +219,7 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       newGame must beSuccess.like {
         case drawnGame =>
           drawnGame.situation.end must beTrue
-          drawnGame.situation.variantDraw must beTrue
+          drawnGame.situation.autoDraw must beTrue
           drawnGame.situation.status must beSome.like {
             case status => status == Status.Draw
           }
@@ -235,7 +235,7 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       newGame must beSuccess.like {
         case nonDrawnGame =>
           nonDrawnGame.situation.end must beFalse
-          nonDrawnGame.situation.variantDraw must beFalse
+          nonDrawnGame.situation.autoDraw must beFalse
           nonDrawnGame.situation.status must beNone
       }
     }

--- a/src/test/scala/AntichessVariantTest.scala
+++ b/src/test/scala/AntichessVariantTest.scala
@@ -240,6 +240,35 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       }
     }
 
+    "Not be drawn where a white bishop can attack a black pawn in an almost closed position" in {
+      val position = "5b2/1P4p1/4B1P1/4p3/4P3/8/8/8 w - -"
+      val originalGame = fenToGame(position, Antichess)
+
+      val newGame = originalGame flatMap(_.apply(Pos.B7, Pos.B8, Bishop.some)) map (_._1)
+ 
+      newGame must beSuccess.like {
+        case nonDrawnGame =>
+          nonDrawnGame.situation.end must beFalse
+          nonDrawnGame.situation.autoDraw must beFalse
+          nonDrawnGame.situation.status must beNone
+      }
+ 
+    }
+
+    "Not be drawn where a pawn is unattackable, but is blocked by a bishop, not a pawn" in {
+      val position = "8/8/4BbP1/4p3/4P3/8/8/8 b - -"
+      val originalGame = fenToGame(position, Antichess)
+
+      val newGame = originalGame flatMap(_.playMoves(Pos.F6 -> Pos.G7))
+
+      newGame must beSuccess.like {
+        case nonDrawnGame =>
+          nonDrawnGame.situation.end must beFalse
+          nonDrawnGame.situation.autoDraw must beFalse
+          nonDrawnGame.situation.status must beNone
+      }
+    }
+
     "Not be drawn on insufficient mating material" in {
       val positionString = "4K3/8/1b6/8/8/8/5B2/3k4 b - -"
       val maybeGame = fenToGame(positionString, Antichess)

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -331,7 +331,7 @@ class AtomicVariantTest extends ChessTest {
       }
     }
 
-    "Game is not a draw when the last piece a player has other than their king is a pawn " in {
+    "Game is not a draw when the last piece a player has other than their king is a pawn that is blocked by a mobile piece" in {
       val position = "3Q4/2b2k2/5P2/8/8/8/6K1/8 b - - 0 57"
       val game = fenToGame(position, Atomic)
 
@@ -416,6 +416,21 @@ class AtomicVariantTest extends ChessTest {
         case gm =>
           gm.situation.board.variant.insufficientWinningMaterial(gm.situation, Color.White) must beTrue
       }
+
+    }
+
+    "An automatic draw in a closed position with only kings and pawns which cannot move" in {
+      val position = "8/8/6p1/3K4/6P1/2k5/8/8 w - -"
+      val originalGame = fenToGame(position, Atomic)
+
+      val game = originalGame flatMap(_.playMoves(Pos.G4 -> Pos.G5))
+
+      game must beSuccess.like {
+        case gm =>
+          gm.situation.autoDraw must beTrue
+          gm.situation.end must beTrue
+      }
+
 
     }
 

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -110,7 +110,7 @@ class AtomicVariantTest extends ChessTest {
       game must beSuccess.like {
         case game =>
           game.situation.end must beTrue
-          game.situation.variantDraw must beTrue
+          game.situation.autoDraw must beTrue
           game.situation.winner must beNone
           game.situation.status must beSome.like {
             case status => status == Status.Draw
@@ -399,6 +399,24 @@ class AtomicVariantTest extends ChessTest {
       ))
 
       newGame must beSuccess
+    }
+
+    "Identify that a player does not have sufficient material to win when they only have a king" in {
+      val position = "8/8/8/8/7p/2k3q1/2K3P1/8 b - - 19 54"
+      val game = fenToGame(position, Atomic)
+
+      game must beSuccess.like {
+        case gm =>
+          gm.situation.end must beFalse
+      }
+
+      val drawGame = game flatMap(_.playMoves(Pos.G3 -> Pos.G2))
+
+      drawGame must beSuccess.like {
+        case gm =>
+          gm.situation.board.variant.insufficientWinningMaterial(gm.situation, Color.White) must beTrue
+      }
+
     }
 
     "Not draw inappropriately on bishops vs bishops (where an explosion taking out the king is possible)" in {

--- a/src/test/scala/HordeVariantTest.scala
+++ b/src/test/scala/HordeVariantTest.scala
@@ -13,7 +13,6 @@ class HordeVariantTest extends ChessTest {
       game must beSuccess.like {
         case gm =>
           gm.situation.board.variant.insufficientWinningMaterial(gm.situation, Color.white) must beTrue
-      
       }
     }
 
@@ -35,6 +34,16 @@ class HordeVariantTest extends ChessTest {
       game must beSuccess.like {
         case gm =>
           gm.situation.board.variant.insufficientWinningMaterial(gm.situation, Color.white) must beTrue
+      }
+    }
+
+    "Must not be insufficient winning material with 3 minor pieces left" in {
+      val position = "8/2k5/3q4/8/8/3B4/4NB2/8 w - -"
+      val game = fenToGame(position, Horde)
+
+      game must beSuccess.like {
+        case gm =>
+          gm.situation.board.variant.insufficientWinningMaterial(gm.situation, Color.white) must beFalse
       }
     }
   }

--- a/src/test/scala/HordeVariantTest.scala
+++ b/src/test/scala/HordeVariantTest.scala
@@ -1,0 +1,41 @@
+package chess
+
+import variant.Horde
+
+class HordeVariantTest extends ChessTest {
+
+  "Horde chess" should {
+    
+    "Must recognise insufficient winning material for white with 1 pawn left." in {
+      val position = "8/2k5/3q4/8/8/8/1P6/8 w - -"
+      val game = fenToGame(position, Horde)
+
+      game must beSuccess.like {
+        case gm =>
+          gm.situation.board.variant.insufficientWinningMaterial(gm.situation, Color.white) must beTrue
+      
+      }
+    }
+
+    "Must recognise insufficient winning material for white with 1 queen left." in {
+      val position = "8/2k5/3q4/8/8/1Q6/8/8 w - -"
+      val game = fenToGame(position, Horde)
+
+      game must beSuccess.like {
+        case gm =>
+          gm.situation.board.variant.insufficientWinningMaterial(gm.situation, Color.white) must beTrue
+      }
+    
+    }
+
+    "Must recognise insufficient winning material for white with only 2 minor pieces left" in {
+      val position = "8/2k5/3q4/8/8/1B2N3/8/8 w - -"
+      val game = fenToGame(position, Horde)
+
+      game must beSuccess.like {
+        case gm =>
+          gm.situation.board.variant.insufficientWinningMaterial(gm.situation, Color.white) must beTrue
+      }
+    }
+  }
+}

--- a/src/test/scala/VariantTest.scala
+++ b/src/test/scala/VariantTest.scala
@@ -12,6 +12,27 @@ class VariantTest extends ChessTest {
     "position pieces correctly" in {
       Standard.pieces must havePairs(A1 -> (White - Rook), B1 -> (White - Knight), C1 -> (White - Bishop), D1 -> (White - Queen), E1 -> (White - King), F1 -> (White - Bishop), G1 -> (White - Knight), H1 -> (White - Rook), A2 -> (White - Pawn), B2 -> (White - Pawn), C2 -> (White - Pawn), D2 -> (White - Pawn), E2 -> (White - Pawn), F2 -> (White - Pawn), G2 -> (White - Pawn), H2 -> (White - Pawn), A7 -> (Black - Pawn), B7 -> (Black - Pawn), C7 -> (Black - Pawn), D7 -> (Black - Pawn), E7 -> (Black - Pawn), F7 -> (Black - Pawn), G7 -> (Black - Pawn), H7 -> (Black - Pawn), A8 -> (Black - Rook), B8 -> (Black - Knight), C8 -> (Black - Bishop), D8 -> (Black - Queen), E8 -> (Black - King), F8 -> (Black - Bishop), G8 -> (Black - Knight), H8 -> (Black - Rook))
     }
+
+    "Identify insufficient mating material when called (bishop)." in {
+      val position = "8/3k4/2q5/8/8/K1B5/8/8 w - -"
+      val game = fenToGame(position, Standard)
+
+      game should beSuccess.like {
+        case gm =>
+          gm.situation.board.variant.insufficientWinningMaterial(gm.situation, Color.white) must beTrue
+      }
+    }
+
+    "Identify insufficient mating material when called (knight)." in {
+      val position = "8/3k4/2q5/8/8/K1N5/8/8 w - -"
+      val game = fenToGame(position, Standard)
+
+      game should beSuccess.like {
+        case gm =>
+          gm.situation.board.variant.insufficientWinningMaterial(gm.situation, Color.white) must beTrue
+      }
+    
+    }
   }
 
   "chess960" should {


### PR DESCRIPTION
This pull request fixes some of the issues highlighted in: https://github.com/ornicar/lila/issues/773

If a stronger player flags against a player who doesn't have sufficient material to win, the game will be a draw.

**Requires a change to lila**. If accepted, the following line https://github.com/ornicar/lila/blob/b73800ddb46eff91a64963fc9b895cbb893b4fb4/modules/round/src/main/Round.scala#L215 will have to be updated to use the variant's 'insufficientWinningMaterial' method.

It's possible that the autodraw condition for atomic that we've had for a while might not be appropriate. Perhaps we can raise a separate issue to consider the debate in http://en.lichess.org/forum/team-atomic-chess-theoreticians/help-fix-a-lichess-bug-insufficient-material-in-atomic or update to this end rather than closing it.
