### PR TITLE
hash consistency when king is captured

### DIFF
--- a/src/main/scala/Hash.scala
+++ b/src/main/scala/Hash.scala
@@ -47,10 +47,13 @@ final class Hash(size: Int) {
 
     val turn = stm.fold(List(whiteTurnMask), List.empty)
 
-    val castling = (situation.history.castles.toList zip castlingMasks).map {
-      case (canCastle, castlingMask) =>
-        if (canCastle) castlingMask else zeroMask
-    }
+    val castling =
+      if (board.variant.allowsCastling)
+        (situation.history.castles.toList zip castlingMasks).map {
+          case (canCastle, castlingMask) =>
+            if (canCastle) castlingMask else zeroMask
+        }
+      else List.empty
 
     val ep = situation.enPassantSquare match {
       case Some(pos) => List(enPassantMasks(pos.x - 1))

--- a/src/main/scala/Move.scala
+++ b/src/main/scala/Move.scala
@@ -37,7 +37,7 @@ case class Move(
         else h2
 
       // opponent broken castles
-      (for {
+      val h4 = (for {
         cPos ← capture
         cPiece ← before(cPos)
         if cPiece is Rook
@@ -45,6 +45,9 @@ case class Move(
         side ← Side.kingRookSide(kingPos, cPos)
         if h3 canCastle !color on side
       } yield h3.withoutCastle(!color, side)) | h3
+
+      // captured king
+      if (after kingPosOf !color isDefined) h4 else h4 withoutCastles !color
     }
 
     board.variant.finalizeBoard(board, toUci, capture flatMap before.apply) updateHistory { h =>

--- a/src/test/scala/HashTest.scala
+++ b/src/test/scala/HashTest.scala
@@ -2,7 +2,7 @@ package chess
 
 import Pos._
 import format.Uci
-import variant.{Standard, Crazyhouse, ThreeCheck}
+import variant.{Standard, Crazyhouse, ThreeCheck, Antichess}
 
 class HashTest extends ChessTest {
 
@@ -117,6 +117,20 @@ class HashTest extends ChessTest {
       // 5 ... Bxf3
       val fenAfter = "r2qkb1r/ppp1pppp/2n2n2/3p2B1/3P4/4Pb2/PPP1BPPP/RN1QK2R/n w KQkq - 10 6"
       val situationAfter = (format.Forsyth << fenAfter) get
+      val hashAfter = hash(situationAfter)
+
+      hashAfterMove mustEqual hashAfter
+    }
+
+    "be consistent in antichess" in {
+      val fen = "rnbqkb1r/ppp1pppp/3p1n2/1B6/8/4P3/PPPP1PPP/RNBQK1NR w KQkq - 2 3"
+      val situation = ((format.Forsyth << fen) get) withVariant Antichess
+      val move = situation.move(Pos.B5, Pos.E8, None).toOption.get
+      val hashAfterMove = hash(move.situationAfter)
+
+      // 3. BxK
+      val fenAfter = "rnbqBb1r/ppp1pppp/3p1n2/8/8/4P3/PPPP1PPP/RNBQK1NR b KQkq - 0 3"
+      val situationAfter = ((format.Forsyth << fenAfter) get) withVariant Antichess
       val hashAfter = hash(situationAfter)
 
       hashAfterMove mustEqual hashAfter


### PR DESCRIPTION
this is a failing test with the bug.

capturing the king does not remove castling rights. parsing a fen with a missing king will remove castling rights.

(aditionally, since castling is disallowed in racing kings and antichess, it's probably best to get rid of castling rights entirely in those cases.)