### PR TITLE
castling right initialization for variants

### DIFF
--- a/src/main/scala/Board.scala
+++ b/src/main/scala/Board.scala
@@ -149,9 +149,12 @@ object Board {
   import Pos._
 
   def apply(pieces: Traversable[(Pos, Piece)], variant: Variant): Board =
-    Board(pieces.toMap, History(), variant, variantCrazyData(variant))
+    Board(pieces.toMap, if (variant.allowsCastling) Castles.all else Castles.none, variant)
 
-  def init(variant: Variant): Board = Board(variant.pieces, variant)
+  def apply(pieces: Traversable[(Pos, Piece)], castles: Castles, variant: Variant): Board =
+    Board(pieces.toMap, History(castles = castles), variant, variantCrazyData(variant))
+
+  def init(variant: Variant): Board = Board(variant.pieces, variant.castles, variant)
 
   def empty(variant: Variant): Board = Board(Nil, variant)
 

--- a/src/main/scala/Setup.scala
+++ b/src/main/scala/Setup.scala
@@ -3,6 +3,6 @@ package chess
 object Setup {
 
   def apply(variant: chess.variant.Variant): Game = Game(
-    board = Board(pieces = variant.pieces, variant = variant)
+    board = Board(pieces = variant.pieces, castles = variant.castles, variant = variant)
   )
 }

--- a/src/main/scala/format/Forsyth.scala
+++ b/src/main/scala/format/Forsyth.scala
@@ -224,6 +224,8 @@ object Forsyth {
 
   private[chess] def fixCastles(variant: Variant, fen: String): Option[String] =
     fen.split(' ').toList match {
+      case boardStr :: color :: castlesStr :: rest if !variant.allowsCastling =>
+        Some(s"$boardStr $color - ${rest.mkString(" ")}")
       case boardStr :: color :: castlesStr :: rest => makeBoard(variant, boardStr) map { board =>
         val c1 = Castles(castlesStr)
         val wkPos = board.kingPosOf(White)

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -10,7 +10,8 @@ case object Antichess extends Variant(
   standardInitialPosition = true) {
 
   // In antichess, it is not permitted to castle
-  override def allowsCastling = false
+  override val castles = Castles.none
+  override val initialFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"
 
   // In antichess, the king can't be put into check so we always return false
   override def kingThreatened(board: Board, color: Color, to: Pos, filter: Piece => Boolean = _ => true) = false

--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -35,6 +35,8 @@ case object Horde extends Variant(
     blackPieces ++ whitePawnsHoard
   }
 
+  override val castles = Castles("kq")
+
   override val initialFen = "rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1"
 
   override def valid(board: Board, strict: Boolean) =

--- a/src/main/scala/variant/RacingKings.scala
+++ b/src/main/scala/variant/RacingKings.scala
@@ -32,6 +32,8 @@ case object RacingKings extends Variant(
     Pos.H1 -> White.queen,
     Pos.H2 -> White.king)
 
+  override val castles = Castles.none
+
   override val initialFen = "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1"
 
   override def insufficientWinningMaterial(board: Board) = false

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -25,12 +25,13 @@ abstract class Variant(
 
   def exotic = !standard
 
-  // Some variants do not allow castling
-  def allowsCastling = true
+  def allowsCastling = !castles.isEmpty
 
   protected def backRank = IndexedSeq(Rook, Knight, Bishop, Queen, King, Bishop, Knight, Rook)
 
   def pieces: Map[Pos, Piece] = Variant.symmetricRank(backRank)
+
+  def castles: Castles = Castles.all
 
   def initialFen = format.Forsyth.initial
 

--- a/src/test/scala/AntichessVariantTest.scala
+++ b/src/test/scala/AntichessVariantTest.scala
@@ -54,7 +54,7 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       afterFirstMove must beSuccess.like {
         case newGame =>
           val fen = Forsyth >> newGame
-          fen mustEqual "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
+          fen mustEqual "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b - - 0 1"
       }
     }
 

--- a/src/test/scala/BoardTest.scala
+++ b/src/test/scala/BoardTest.scala
@@ -16,6 +16,10 @@ class BoardTest extends ChessTest {
       board.pieces must not beEmpty
     }
 
+    "have castling rights by default" in {
+      board.history.castles == Castles.all
+    }
+
     "allow a piece to be placed" in {
       board place White - Rook at E3 must beSuccess.like {
         case b => b(E3) mustEqual Some(White - Rook)

--- a/src/test/scala/VariantTest.scala
+++ b/src/test/scala/VariantTest.scala
@@ -40,6 +40,10 @@ class VariantTest extends ChessTest {
     "position pieces correctly" in {
       Chess960.pieces must havePair(A2 -> (White - Pawn))
     }
+
+    "initialize the board with castling rights" in {
+      Board.init(Chess960).history.castles must_== Castles.all
+    }
   }
 
   "kingOfTheHill" should {
@@ -75,6 +79,10 @@ PP
         }
 
       }
+    }
+
+    "initialize the board with castling rights" in {
+      Board.init(KingOfTheHill).history.castles must_== Castles.all
     }
   }
 
@@ -143,6 +151,9 @@ K  r
       }
     }
 
+    "initialize the board with castling rights" in {
+      Board.init(KingOfTheHill).history.castles must_== Castles.all
+    }
   }
 
   "racingKings" should {
@@ -230,6 +241,22 @@ K  r
           game.situation.end must beTrue
           game.situation.status must beEqualTo(Status.Draw.some)
       }
+    }
+
+    "initialize the board without castling rights" in {
+      Board.init(RacingKings).history.castles.isEmpty must beTrue
+    }
+  }
+
+  "antichess" should {
+    "initialize the board without castling rights" in {
+      Board.init(Antichess).history.castles.isEmpty must beTrue
+    }
+  }
+
+  "horde" should {
+    "initialize the board with black castling rights" in {
+      Board.init(Horde).history.castles must_== Castles("kq")
     }
   }
 }

--- a/src/test/scala/format/ForsythTest.scala
+++ b/src/test/scala/format/ForsythTest.scala
@@ -239,6 +239,11 @@ class ForsythTest extends ChessTest {
         case s => s.board.history.castles must_== Castles.none
       }
     }
+    "castling not allowed in variant" in {
+      val fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+      val fix = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"
+      f.fixCastles(Antichess, fen) must beSome(fix)
+    }
   }
   "ignore impossible en passant squares" should {
     "with queen instead of pawn" in {


### PR DESCRIPTION
As far as the opening explorer and hash consistency are concerned, #66 did the job. However boards should also be initialized with the correct castling rights (in the first place).

* [X] All castling rights in Standard, Chess960, ThreeCheck, KingOfTheHill, Atomic, Crazyhouse
* [x] None in Antichess and RacingKings
* [x] Black in Horde