### PR TITLE
hash consistency when rook is (indirectly) exploded in atomic

### DIFF
--- a/src/main/scala/Board.scala
+++ b/src/main/scala/Board.scala
@@ -100,6 +100,8 @@ case class Board(
     b3 ← b2.place(pawn.color.queen, pos)
   } yield b3
 
+  def castles: Castles = history.castles
+
   def withHistory(h: History): Board = copy(history = h)
 
   def withCastles(c: Castles) = withHistory(history withCastles c)
@@ -118,6 +120,25 @@ case class Board(
   def withCrazyData(f: Crazyhouse.Data => Crazyhouse.Data): Board = withCrazyData(f(crazyData | Crazyhouse.Data.init))
 
   def ensureCrazyData = withCrazyData(crazyData | Crazyhouse.Data.init)
+
+  def fixCastles: Board = withCastles {
+    if (variant.allowsCastling) {
+      val wkPos = kingPosOf(White)
+      val bkPos = kingPosOf(Black)
+      val wkReady = wkPos.fold(false)(_.y == 1)
+      val bkReady = bkPos.fold(false)(_.y == 8)
+      def rookReady(color: Color, kPos: Option[Pos], left: Boolean) = kPos.fold(false) { kp =>
+        actorsOf(color) exists { a =>
+          a.piece.role == Rook && a.pos.y == kp.y && (left ^ (a.pos.x > kp.x))
+        }
+      }
+      Castles(
+        whiteKingSide = castles.whiteKingSide && wkReady && rookReady(White, wkPos, false),
+        whiteQueenSide = castles.whiteQueenSide && wkReady && rookReady(White, wkPos, true),
+        blackKingSide = castles.blackKingSide && bkReady && rookReady(Black, bkPos, false),
+        blackQueenSide = castles.blackQueenSide && bkReady && rookReady(Black, bkPos, true))
+    } else Castles.none
+  }
 
   def updateHistory(f: History => History) = copy(history = f(history))
 

--- a/src/main/scala/Move.scala
+++ b/src/main/scala/Move.scala
@@ -26,29 +26,15 @@ case class Move(
       val h2 = h1.copy(lastMove = Some(toUci))
 
       // my broken castles
-      val h3 =
-        if ((piece is King) && h2.canCastle(color).any)
-          h2 withoutCastles color
-        else if (piece is Rook) (for {
-          kingPos ← after kingPosOf color
-          side ← Side.kingRookSide(kingPos, orig)
-          if h2 canCastle color on side
-        } yield h2.withoutCastle(color, side)) | h2
-        else h2
-
-      // opponent broken castles
-      val h4 = (for {
-        cPos ← capture
-        cPiece ← before(cPos)
-        if cPiece is Rook
-        kingPos ← after kingPosOf !color
-        side ← Side.kingRookSide(kingPos, cPos)
-        if h3 canCastle !color on side
-      } yield h3.withoutCastle(!color, side)) | h3
-
-      // captured king
-      if (after kingPosOf !color isDefined) h4 else h4 withoutCastles !color
-    }
+      if ((piece is King) && h2.canCastle(color).any)
+        h2 withoutCastles color
+      else if (piece is Rook) (for {
+        kingPos ← after kingPosOf color
+        side ← Side.kingRookSide(kingPos, orig)
+        if h2 canCastle color on side
+      } yield h2.withoutCastle(color, side)) | h2
+      else h2
+    } fixCastles
 
     board.variant.finalizeBoard(board, toUci, capture flatMap before.apply) updateHistory { h =>
       // Update position hashes last, only after updating the board,

--- a/src/main/scala/Situation.scala
+++ b/src/main/scala/Situation.scala
@@ -53,6 +53,10 @@ case class Situation(board: Board, color: Color) {
   def drop(role: Role, pos: Pos): Valid[Drop] =
     board.variant.drop(this, role, pos)
 
+  def fixCastles = copy(
+    board = board fixCastles
+  )
+
   def withHistory(history: History) = copy(
     board = board withHistory history
   )

--- a/src/test/scala/HashTest.scala
+++ b/src/test/scala/HashTest.scala
@@ -2,7 +2,7 @@ package chess
 
 import Pos._
 import format.Uci
-import variant.{Standard, Crazyhouse, ThreeCheck, Antichess}
+import variant.{ Standard, Crazyhouse, ThreeCheck, Antichess, Atomic }
 
 class HashTest extends ChessTest {
 
@@ -122,7 +122,7 @@ class HashTest extends ChessTest {
       hashAfterMove mustEqual hashAfter
     }
 
-    "be consistent in antichess" in {
+    "be consistent when king is captured in antichess" in {
       val fen = "rnbqkb1r/ppp1pppp/3p1n2/1B6/8/4P3/PPPP1PPP/RNBQK1NR w KQkq - 2 3"
       val situation = ((format.Forsyth << fen) get) withVariant Antichess
       val move = situation.move(Pos.B5, Pos.E8, None).toOption.get
@@ -131,6 +131,20 @@ class HashTest extends ChessTest {
       // 3. BxK
       val fenAfter = "rnbqBb1r/ppp1pppp/3p1n2/8/8/4P3/PPPP1PPP/RNBQK1NR b KQkq - 0 3"
       val situationAfter = ((format.Forsyth << fenAfter) get) withVariant Antichess
+      val hashAfter = hash(situationAfter)
+
+      hashAfterMove mustEqual hashAfter
+    }
+
+    "be consistent when rook is exploded in atomic" in {
+      val fen = "rnbqkb1r/ppppp1pp/5p1n/6N1/8/8/PPPPPPPP/RNBQKB1R w KQkq - 2 3"
+      val situation = format.Forsyth.<<@(Atomic, fen).get
+      val move = situation.move(Pos.G5, Pos.H7, None).toOption.get
+      val hashAfterMove = hash(move.situationAfter)
+
+      // 3. Nxh7
+      val fenAfter = "rnbqkb2/ppppp1p1/5p2/8/8/8/PPPPPPPP/RNBQKB1R b KQkq - 0 3"
+      val situationAfter = format.Forsyth.<<@(Atomic, fenAfter).get
       val hashAfter = hash(situationAfter)
 
       hashAfterMove mustEqual hashAfter

--- a/src/test/scala/format/ForsythTest.scala
+++ b/src/test/scala/format/ForsythTest.scala
@@ -184,7 +184,7 @@ class ForsythTest extends ChessTest {
     }
   }
   "fix impossible castle flags" should {
-    def fixCastles(fen: String) = f.fixCastles(Standard, fen)
+    def fixCastles(fen: String) = (f << fen).map(f >> _)
     "messed up" in {
       val fen = "yayyyyyyyyyyy"
       fixCastles(fen) must beNone
@@ -242,7 +242,7 @@ class ForsythTest extends ChessTest {
     "castling not allowed in variant" in {
       val fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
       val fix = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"
-      f.fixCastles(Antichess, fen) must beSome(fix)
+      (f <<@(Antichess, fen)).map(f >> _) must beSome(fix)
     }
   }
   "ignore impossible en passant squares" should {


### PR DESCRIPTION
castling rights should be removed, then. here's a failing test.