### PR TITLE
treat fromPosition as chess960 with regard to uci

### DIFF
--- a/src/main/scala/format/UciDump.scala
+++ b/src/main/scala/format/UciDump.scala
@@ -17,8 +17,8 @@ object UciDump {
 
   def move(variant: Variant)(mod: MoveOrDrop): String = mod match {
     case Left(m) => m.castle.fold(m.toUci.uci) {
-      case ((kf, kt), (rf, rt)) if kf == kt || variant.chess960 => kf.key + rf.key
-      case ((kf, kt), _)                                        => kf.key + kt.key
+      case ((kf, kt), (rf, rt)) if kf == kt || variant.chess960 || variant.fromPosition => kf.key + rf.key
+      case ((kf, kt), _) => kf.key + kt.key
     }
     case Right(d) => d.toUci.uci
   }

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -15,6 +15,7 @@ abstract class Variant(
 
   def standard = this == Standard
   def chess960 = this == Chess960
+  def fromPosition = this == FromPosition
   def kingOfTheHill = this == KingOfTheHill
   def threeCheck = this == ThreeCheck
   def antichess = this == Antichess


### PR DESCRIPTION
FromPosition can have non-standard (Chess960) castling rights. So we have to use the more general Chess960 UCI notation for castling moves (or start to distinguish between standard and non-standard FromPosition).

Together with niklasf/fishnet@0ce633b037965b4ac016e126f2c8b006a164bc5b this fixes ornicar/lila#1132.