### PR TITLE
Adjust maxGraceMillis

### DIFF
--- a/src/main/scala/Clock.scala
+++ b/src/main/scala/Clock.scala
@@ -183,7 +183,7 @@ object Clock {
   // no more than this time will be offered to the lagging player
   val maxLagToCompensate = 1f
   // no more than this time to get the last move in
-  val maxGraceMillis = 800
+  val maxGraceMillis = 1000
 
   def apply(
     limit: Int,


### PR DESCRIPTION
Set maxGraceMillis to 1000 so that lagging players aren't prematurely flagged.
maxGraceMillis should probably be at least as high as maxLagToCompensate.