### PR TITLE
Adjust emergency time cutoffs

### DIFF
--- a/src/main/scala/Clock.scala
+++ b/src/main/scala/Clock.scala
@@ -37,7 +37,8 @@ sealed trait Clock {
 
   def estimateTotalTime = limit + estimateTotalIncrement
 
-  def emergTime: Int = math.round(math.min(20, math.max(2, estimateTotalTime / 15)))
+  // Emergency time cutoff, in seconds.
+  def emergTime: Int = math.round(math.min(60, math.max(10, estimateTotalTime / 8)))
 
   def stop: PausedClock
 


### PR DESCRIPTION
Change math to time / 8, min 10s, max 60s
- 1 0 game => 10s warning
- 2 0 game => 15s warning
- 10 0 game => 60s warning