### PR TITLE
RFC: Ignore increment when calculating emerg alert

### DIFF
--- a/src/main/scala/Clock.scala
+++ b/src/main/scala/Clock.scala
@@ -38,7 +38,7 @@ sealed trait Clock {
   def estimateTotalTime = limit + estimateTotalIncrement
 
   // Emergency time cutoff, in seconds.
-  def emergTime: Int = math.round(math.min(60, math.max(10, estimateTotalTime / 8)))
+  def emergTime: Int = math.round(math.min(60, math.max(10, limit / 8)))
 
   def stop: PausedClock
 


### PR DESCRIPTION
Follow up from #77. The reason is as follows:

- The current math gives a higher alert for a game with
increment, i.e. 2 0 alerts at 15s, but 2 6 alerts at 45s.
Assuming the game has 10 moves left, the player in the 2 6
game actually has 105s left to finish. Even a 15s alert in
2 6 isn't nearly as dire as in 2 0.
- Simpler alert math is better because it is more intuitive
and predictable by users. In this spirit let's consider
removing the increment from the emerg cutoff calculation.