### PR TITLE
Test rendering PGN variations

### DIFF
--- a/src/test/scala/format/pgn/RenderTest.scala
+++ b/src/test/scala/format/pgn/RenderTest.scala
@@ -148,5 +148,35 @@ opening theory } 10. Bxc6 (10. O-O Bxc3 11. Bxc6 Bxb2 12. Bxb7 Bxa1 13.
       )
       pgn.toString must_== """1. d3?! Nc6 $10 2. Qd2 Nb4?? $18 $138 3. Qxb4 $7"""
     }
+
+    "be correct with variations" in {
+      val pgn = Pgn(
+        tags = List(),
+        turns = List(
+          Turn(
+            number = 1,
+            white = Move("d4", variations = List(
+              List(
+                Turn(
+                  number = 1,
+                  white = Move("e4").some,
+                  black = None
+                )
+              )
+            )).some,
+            black = Move("Nf6", variations = List(
+              List(
+                Turn(
+                  number = 1,
+                  white = None,
+                  black = Move("d5").some
+                )
+              )
+            )).some
+          )
+        )
+      )
+      pgn.toString must_== """1. d4 (1. e4) 1... Nf6 (1... d5)"""
+    }
   }
 }


### PR DESCRIPTION
Regarding ornicar/lila#1942: The minimal problematic example gets rendered correctly from a handwritten PGN model. Problem must be before.