### PR TITLE
provide initial fens with 3check and zh syntax

### DIFF
--- a/src/main/scala/variant/Crazyhouse.scala
+++ b/src/main/scala/variant/Crazyhouse.scala
@@ -13,6 +13,8 @@ case object Crazyhouse extends Variant(
   title = "Captured pieces can be dropped back on the board instead of moving a piece.",
   standardInitialPosition = true) {
 
+  override val initialFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR/ w KQkq - 0 1"
+
   override def valid(board: Board, strict: Boolean) = {
     val pieces = board.pieces.values
     (Color.all forall validSide(board, false)_) &&

--- a/src/main/scala/variant/ThreeCheck.scala
+++ b/src/main/scala/variant/ThreeCheck.scala
@@ -9,6 +9,8 @@ case object ThreeCheck extends Variant(
   title = "Check your opponent 3 times to win the game.",
   standardInitialPosition = true) {
 
+  override val initialFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 +0+0"
+
   override def finalizeBoard(board: Board, uci: format.Uci, capture: Option[Piece]): Board =
     board updateHistory {
       _.withCheck(Color.White, board.checkWhite).withCheck(Color.Black, board.checkBlack)


### PR DESCRIPTION
The new SF is sensitive to a missing +0+0 in threecheck fens.

```><> 1: DEBUG: Got job: {"work":{"type":"analysis","id":"Yxjn76nP"},"nodes":3500000,"game_id":"KzjTw1Fp","position":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1","variant":"threeCheck","moves":"e2e4 e7e6 b1c3 f8b4 g1f3 g8f6 f1d3 c7c6 b2b3 d7d5 e4d5 f6d5 c1b2 b4c3 b2c3 d5c3 d2c3 d8f6 d1d2 b8d7 e1g1 b7b6 a1e1 c8b7 e1e6 f6e6 f1e1 e8c8 e1e6 f7e6 d2e2 h8e8 d3a6 c8c7 f3d4 c7b8 e2e5"}```

This leads to bugs like: https://de.lichess.org/forum/lichess-feedback/3-check-computer-analysis-not-giving-any-evals