### PR TITLE
Add condition for one player having all the bishops

### DIFF
--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -12,13 +12,17 @@ object InsufficientMatingMaterial {
 
   /**
    * Returns true when the only non-king pieces that remain are bishops that cannot
-   * capture each other.
+   * capture each other and cannot checkmate (in atomic chess).
    */
   def bishopsOnDifferentColor(board: Board) = {
     val notKingPieces = nonKingPieces(board)
     val onlyBishopsRemain = !notKingPieces.exists(_._2.role != Bishop)
 
+    def bishopsOnSameColor  = notKingPieces.map(_._1.color).distinct.size == 1
+    def bishopsAreSameColor = notKingPieces.map(_._2.color).distinct.size == 1
+
     if (!onlyBishopsRemain) false
+    else if (bishopsAreSameColor) notKingPieces.size < 3 || bishopsOnSameColor
     else {
       val whitePlayerBishops = notKingPieces.filter(_._2.color == Color.White)
       val blackPlayerBishops = notKingPieces.filter(_._2.color == Color.Black)
@@ -36,10 +40,10 @@ object InsufficientMatingMaterial {
     val blockingPosition = Actor.posAheadOfPawn(pawn.pos, pawn.piece.color)
     blockingPosition.flatMap(board.actorAt(_)).exists(_.piece.is(Pawn))
   }
+
   /*
    * Determines whether a board position is an automatic draw due to neither player
    * being able to mate the other as informed by the traditional chess rules.
-   *
    */
   def apply(board: Board) = {
 

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -446,5 +446,18 @@ class AtomicVariantTest extends ChessTest {
           game.situation.end must beFalse
       }
     }
+
+    "Not draw inappropriately on three bishops (of both square colors)" in {
+      val position = "8/5k2/8/8/8/8/4pKb1/5b2 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
   }
 }


### PR DESCRIPTION
Because endgame explorer correctly reveals that most positions with >= 3 bishops win by force, fix atomic chess implementation accordingly:
http://en.lichess.org/forum/lichess-feedback/this-should-not-a-system-draw-because-it-is-possible-to-checkmate#4