### PR TITLE
Advanced atomic stalemate detection

### DIFF
--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -42,7 +42,22 @@ object InsufficientMatingMaterial {
     lazy val piecesAreSameColor = notKingPieces.map {case (_, piece) => piece.color}.distinct.size < 2
 
     if (onlyBishopsRemain && piecesAreSameColor) piecesOnSameColor
+    else if (onlyBishopsRemain && !piecesOnSameColor) notKingPieces.size < 3
     else bishopsCannotCapture(board)
+  }
+
+  /**
+   * Returns true when the only non-king pieces of a color that remain are bishops that cannot checkmate.
+   */
+  def bishopsCannotCheckmate(board: Board, color: Color) = {
+    val notKingPieces = nonKingPieces(board)
+    lazy val opponentPieces = notKingPieces.filter {case (_, piece) => piece.color != color}
+    val onlyBishopsRemain = nonKingNonBishopPieceMap(board).isEmpty
+    lazy val piecesOnSameColor  = notKingPieces.map {case (pos, _) => pos.color}.distinct.size < 2
+    lazy val piecesAreSameColor = notKingPieces.map {case (_, piece) => piece.color}.distinct.size < 2
+
+    if (onlyBishopsRemain && piecesAreSameColor) piecesOnSameColor
+    else opponentPieces.size >= 2 || bishopsCannotCapture(board)
   }
 
   /**

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -38,9 +38,8 @@ object InsufficientMatingMaterial {
   def bishopsCannotCheckmate(board: Board) = {
     val notKingPieces = nonKingPieces(board)
     val onlyBishopsRemain = nonKingNonBishopPieceMap(board).isEmpty
-
-    def piecesOnSameColor  = notKingPieces.map {case (pos, _) => pos.color}.distinct.size < 2
-    def piecesAreSameColor = notKingPieces.map {case (_, piece) => piece.color}.distinct.size < 2
+    lazy val piecesOnSameColor  = notKingPieces.map {case (pos, _) => pos.color}.distinct.size < 2
+    lazy val piecesAreSameColor = notKingPieces.map {case (_, piece) => piece.color}.distinct.size < 2
 
     if (onlyBishopsRemain && piecesAreSameColor) piecesOnSameColor
     else bishopsCannotCapture(board)
@@ -67,13 +66,13 @@ object InsufficientMatingMaterial {
 
     lazy val notKingPieces = nonKingPieces(board)
 
-    def kingsOnly = board.pieces forall { case (_, piece) => piece is King }
+    val kingsOnly = board.pieces forall { case (_, piece) => piece is King }
 
-    def bishopsOnSameColor =
+    lazy val bishopsOnSameColor =
       notKingPieces.map {case (_, piece) => piece.role}.distinct == List(Bishop) &&
         notKingPieces.map {case (pos, _) => pos.color}.distinct.size == 1
 
-    def singleKnight = notKingPieces.map {case (_, piece) => piece.role} == List(Knight)
+    lazy val singleKnight = notKingPieces.map {case (_, piece) => piece.role} == List(Knight)
 
     kingsOnly || bishopsOnSameColor || singleKnight
   }

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -37,7 +37,7 @@ object InsufficientMatingMaterial {
    */
   def bishopsCannotCheckmate(board: Board) = {
     val notKingPieces = nonKingPieces(board)
-    var onlyBishopsRemain = nonKingNonBishopPieceMap(board).isEmpty
+    val onlyBishopsRemain = nonKingNonBishopPieceMap(board).isEmpty
 
     def piecesOnSameColor  = notKingPieces.map {case (pos, _) => pos.color}.distinct.size < 2
     def piecesAreSameColor = notKingPieces.map {case (_, piece) => piece.color}.distinct.size < 2

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -122,7 +122,7 @@ case object Atomic extends Variant(
     val colorRoles = board.rolesOf(color)
     lazy val onlyBishopsRemain = colorRoles.toSet == Set(King, Bishop)
 
-    colorRoles == List(King) || (onlyBishopsRemain && InsufficientMatingMaterial.bishopsCannotCheckmate(board))
+    colorRoles == List(King) || (onlyBishopsRemain && InsufficientMatingMaterial.bishopsCannotCheckmate(board, color))
   }
 
   /** Atomic chess has a special end where a king has been killed by exploding with an adjacent captured piece */

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -120,7 +120,7 @@ case object Atomic extends Variant(
    */
   override def insufficientWinningMaterial(board: Board, color: Color) = {
     val colorRoles = board.rolesOf(color)
-    def onlyBishopsRemain = colorRoles.toSet == Set(King, Bishop)
+    lazy val onlyBishopsRemain = colorRoles.toSet == Set(King, Bishop)
 
     colorRoles == List(King) || (onlyBishopsRemain && InsufficientMatingMaterial.bishopsCannotCheckmate(board))
   }

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -110,7 +110,7 @@ case object Atomic extends Variant(
   private def atomicClosedPosition(board: Board) = {
     val nonKingBoard = InsufficientMatingMaterial.boardWithNonKingPieces(board)
 
-    InsufficientMatingMaterial.mate(nonKingBoard) || InsufficientMatingMaterial.bishopsCannotCheckmate(board)
+    InsufficientMatingMaterial.noPieceMoves(nonKingBoard) || InsufficientMatingMaterial.bishopsCannotCheckmate(board)
   }
 
   /**
@@ -119,9 +119,10 @@ case object Atomic extends Variant(
    * immobile pawns is not sufficient material to win with.
    */
   override def insufficientWinningMaterial(board: Board, color: Color) = {
-    def onlyBishopsRemain = board.rolesOf(color) == List(King, Bishop)
+    val colorRoles = board.rolesOf(color)
+    def onlyBishopsRemain = colorRoles.toSet == Set(King, Bishop)
 
-    board.rolesOf(color) == List(King) || (onlyBishopsRemain && InsufficientMatingMaterial.bishopsCannotCheckmate(board))
+    colorRoles == List(King) || (onlyBishopsRemain && InsufficientMatingMaterial.bishopsCannotCheckmate(board))
   }
 
   /** Atomic chess has a special end where a king has been killed by exploding with an adjacent captured piece */

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -471,11 +471,24 @@ class AtomicVariantTest extends ChessTest {
       }
     }
 
-    "Not draw inappropriately on three bishops (of both square colors)" in {
-      val position = "8/5k2/8/8/8/8/4pKb1/5b2 b - - 1 44"
+    "Not draw inappropriately on bishop vs bishops (where bishop can eventually checkmate)" in {
+      val position = "1K6/8/8/8/8/8/7b/5Bbk w - -"
       val game = fenToGame(position, Atomic)
       val newGame = game flatMap (_.playMove(
-        Pos.E2, Pos.E1, Bishop.some
+        Pos.B8, Pos.A8, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately if there are only two kings and two opposite square coloured bishops remaining" in {
+      val position = "K7/8/8/8/8/B7/B5p1/k6B b - -"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.G2, Pos.H1, Queen.some
       ))
 
       newGame must beSuccess.like {

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -434,6 +434,30 @@ class AtomicVariantTest extends ChessTest {
 
     }
 
+    "An automatic draw in a closed position" in {
+      val position = "8/8/8/8/1p2k3/1Pp1p1p1/2P1P1P1/N3KB2 w - - 0 1"
+      val game = fenToGame(position, Atomic)
+
+      game must beSuccess.like {
+        case gm =>
+          gm.situation.autoDraw must beTrue
+          gm.situation.end must beTrue
+      }
+
+    }
+
+    "An automatic draw in another closed position" in {
+      val position = "8/8/8/8/1p2k3/1Pp1p1p1/2P1P1P1/NB2K3 w - - 0 1"
+      val game = fenToGame(position, Atomic)
+
+      game must beSuccess.like {
+        case gm =>
+          gm.situation.autoDraw must beTrue
+          gm.situation.end must beTrue
+      }
+
+    }
+
     "Not draw inappropriately on bishops vs bishops (where an explosion taking out the king is possible)" in {
       val position = "B2BBBB1/7P/8/8/8/8/3kb3/4K3 w - - 1 53"
       val game = fenToGame(position, Atomic)


### PR DESCRIPTION
In atomic chess, if removing the kings yields a position where nothing can move, or if only the bishops can move (and cannot capture anything) it is not possible to checkmate.

Please code review and advise whether I need to add more test positions.  Thanks!