### PR TITLE
Fix horde auto-draw bug (lila#2552)

### DIFF
--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -46,6 +46,11 @@ case object Horde extends Variant(
   override def specialEnd(situation: Situation) =
     situation.board.piecesOf(White).isEmpty
 
+  /** In horde chess, black always has a possibility to win the game.
+   *  Auto-drawing the game should never happen, but it did in https://en.lichess.org/xQ2RsU8N#121
+   */
+  override def insufficientWinningMaterial(board: Board) = false
+
   /**
    * In horde chess, white cannot win on * V K or [BN]{2} v K or just one piece since they don't have a king
    * for support.

--- a/src/test/scala/HordeVariantTest.scala
+++ b/src/test/scala/HordeVariantTest.scala
@@ -46,5 +46,15 @@ class HordeVariantTest extends ChessTest {
           gm.situation.board.variant.insufficientWinningMaterial(gm.situation.board, Color.white) must beFalse
       }
     }
+
+    "Must not auto-draw in B vs K endgame, black can win" in {
+      val position = "7B/6k1/8/8/8/8/8/8 b - -"
+      val game = fenToGame(position, Horde)
+
+      game must beSuccess.like {
+        case gm =>
+          gm.situation.board.variant.insufficientWinningMaterial(gm.situation.board) must beFalse
+      }
+    }
   }
 }


### PR DESCRIPTION
Lichess auto-drew in https://en.lichess.org/xQ2RsU8N#121 and this was wrong, black could capture it immediately. In fact, black always has the possibility to win {piece} vs K endgames, white can blunder it away. This means that scalachess must not ever auto-draw the game.