### PR TITLE
accept winboard-style zh pockets in fens

### DIFF
--- a/src/main/scala/format/Forsyth.scala
+++ b/src/main/scala/format/Forsyth.scala
@@ -8,6 +8,7 @@ import variant.{ Variant, Standard }
  * http://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
  *
  * Crazyhouse & Threecheck extensions:
+ * https://github.com/ddugovic/Stockfish/wiki/FEN-extensions
  * http://scidb.sourceforge.net/help/en/FEN.html#ThreeCheck
  */
 object Forsyth {
@@ -102,6 +103,10 @@ object Forsyth {
       case word if (word.count('/' ==) == 8) =>
         val splitted = word.split('/')
         splitted.take(8).mkString -> splitted.lift(8)
+      case word if word.contains('[') && word.endsWith("]") =>
+        word.span('['!=) match {
+          case (position, pockets) => position -> pockets.stripPrefix("[").stripSuffix("]").some
+        }
       case word => word -> None
     }
     {

--- a/src/test/scala/format/ForsythTest.scala
+++ b/src/test/scala/format/ForsythTest.scala
@@ -306,6 +306,14 @@ class ForsythTest extends ChessTest {
           }
         }
       }
+      "winboard pockets" in {
+        f <<< "r1bk3r/ppp2ppp/4p3/1B1pP3/1b1N4/2N2qPp/PPP2NbP/4R1KR[PNq] b - - 39 20" must beSome.like {
+          case s => s.situation.board.crazyData must beSome.like {
+            case Data(Pockets(Pocket(Pawn :: Knight :: Nil), Pocket(Queen :: Nil)), promoted) =>
+              promoted must beEmpty
+          }
+        }
+      }
       "promoted none" in {
         f <<< "2b2rk1/3p2pp/2pNp3/4PpN1/qp1P3P/4P1K1/6P1/1Q6/pPP w - f6 0 36" must beSome.like {
           case s => s.situation.board.crazyData must beSome.like {


### PR DESCRIPTION
useful for interoperability with winboard, cutechess and stockfish

corresponding lila issue: https://github.com/ornicar/lila/issues/2435

/cc @ddugovic, @rpdelaney