### PR TITLE
simplify away Role.attacker

### DIFF
--- a/src/main/scala/Actor.scala
+++ b/src/main/scala/Actor.scala
@@ -94,7 +94,7 @@ case class Actor(
    */
   def kingSafetyMoveFilter(ms: List[Move]): List[Move] = {
     val filter: Piece => Boolean =
-      if ((piece is King)) (_ => true) else if (check) (_.role.attacker) else (_.role.projection)
+      if ((piece is King) || check) (_ => true) else (_.role.projection)
     val stableKingPos = if (piece is King) None else board kingPosOf color
     ms filter { m =>
       board.variant.kingSafety(m, filter, stableKingPos orElse (m.after kingPosOf color))

--- a/src/main/scala/Role.scala
+++ b/src/main/scala/Role.scala
@@ -5,7 +5,6 @@ sealed trait Role {
   lazy val forsythUpper: Char = forsyth.toUpper
   lazy val pgn: Char = forsythUpper
   lazy val name = toString.toLowerCase
-  val attacker: Boolean = true
   val projection: Boolean
   val dirs: Directions
   def dir(from: Pos, to: Pos): Option[Direction]
@@ -19,7 +18,6 @@ case object King extends PromotableRole {
   val forsyth = 'k'
   val dirs: Directions = Queen.dirs
   def dir(from: Pos, to: Pos) = None
-  override val attacker = false
   val projection = false
 }
 

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -65,7 +65,7 @@ abstract class Variant(
 
   def kingSafety(a: Actor, m: Move): Boolean = kingSafety(
     m,
-    if (a.piece is King) (_ => true) else if (a.check) (_.role.attacker) else (_.role.projection),
+    if ((a.piece is King) || a.check) (_ => true) else (_.role.projection),
     if (a.piece.role == King) None else a.board kingPosOf a.color
   )
 


### PR DESCRIPTION
It seems that `role.attacker` is only used in exactly these places. The filters unconditionally return true for kings, which is the only role where `attacker` was `false`.