### PR TITLE
switch to org.specs2.matcher.ValidationMatchers

### DIFF
--- a/src/test/scala/ChessTest.scala
+++ b/src/test/scala/ChessTest.scala
@@ -2,15 +2,12 @@ package chess
 
 import chess.format.{ Forsyth, Visual }
 import chess.variant.Variant
-import org.specs2.matcher.Matcher
+import org.specs2.matcher.{ Matcher, ValidationMatchers }
 import org.specs2.mutable.Specification
-import ornicar.scalalib.test.ValidationMatchers
 import scalaz.{ Validation => V }
 import V.FlatMap._
 
-trait ChessTest
-    extends Specification
-    with ValidationMatchers {
+trait ChessTest extends Specification with ValidationMatchers {
 
   implicit def stringToBoard(str: String): Board = Visual << str
 

--- a/src/test/scala/DecayingStatsTest.scala
+++ b/src/test/scala/DecayingStatsTest.scala
@@ -1,11 +1,10 @@
 package chess
 
 import org.specs2.mutable.Specification
-import ornicar.scalalib.test.ValidationMatchers
 
 import DecayingStats.{ empty => dEmpty }
 
-class DecayingStatsTest extends Specification with ValidationMatchers {
+class DecayingStatsTest extends Specification {
 
   val random = new java.util.Random(2286825201242408115l)
 


### PR DESCRIPTION
removed from scalalib here: https://github.com/ornicar/scalalib/commit/9e268452cfc77da54efb46b639e1cdf026e38bcf