### PR TITLE
reintroduce Centis.abs to fix lila tests

### DIFF
--- a/src/main/scala/Centis.scala
+++ b/src/main/scala/Centis.scala
@@ -20,6 +20,8 @@ case class Centis(centis: Int) extends AnyVal with Ordered[Centis] {
   def *(scalar: Int) = Centis(scalar * centis)
   def unary_- = Centis(-centis)
 
+  def abs: Centis = Centis(centis.abs)
+
   def compare(other: Centis) = centis - other.centis
 
   def atMost(o: Centis) = if (centis > o.centis) o else this


### PR DESCRIPTION
It was only used in tests (now broken) and removed in 70ef53518c4db031ada25d7a16ada078db00756f. 

Most convenient would be to reintroduce it.