### PR TITLE
Rewrite and clean up Clock step

### DIFF
--- a/src/main/scala/Centis.scala
+++ b/src/main/scala/Centis.scala
@@ -2,6 +2,7 @@ package chess
 
 import scala.concurrent.duration._
 
+import scalaz.Monoid
 import ornicar.scalalib.Zero
 
 // maximum centis = Int.MaxValue / 100 / 60 / 60 / 24 = 248 days
@@ -18,6 +19,7 @@ case class Centis(centis: Int) extends AnyVal with Ordered[Centis] {
   def +(other: Centis) = Centis(centis + other.centis)
   def -(other: Centis) = Centis(centis - other.centis)
   def *(scalar: Int) = Centis(scalar * centis)
+  def /(div: Int) = Centis(centis / div)
   def unary_- = Centis(-centis)
 
   def avg(other: Centis) = Centis((centis + other.centis) >> 1)
@@ -32,6 +34,10 @@ case class Centis(centis: Int) extends AnyVal with Ordered[Centis] {
 
 object Centis {
   implicit val zeroInstance = Zero.instance(Centis(0))
+  implicit object CentisMonoid extends Monoid[Centis] {
+    def append(c1: Centis, c2: => Centis) = c1 + c2
+    val zero = Centis(0)
+  }
 
   def apply(value: Long): Centis = Centis {
     if (value > Int.MaxValue) {

--- a/src/main/scala/Centis.scala
+++ b/src/main/scala/Centis.scala
@@ -19,7 +19,7 @@ case class Centis(centis: Int) extends AnyVal with Ordered[Centis] {
   def +(other: Centis) = Centis(centis + other.centis)
   def -(other: Centis) = Centis(centis - other.centis)
   def *(scalar: Int) = Centis(scalar * centis)
-  def /(div: Int) = Centis(centis / div)
+  def /(div: Int) = div != 0 option Centis(centis / div)
   def unary_- = Centis(-centis)
 
   def avg(other: Centis) = Centis((centis + other.centis) >> 1)
@@ -37,6 +37,10 @@ object Centis {
   implicit object CentisMonoid extends Monoid[Centis] {
     def append(c1: Centis, c2: => Centis) = c1 + c2
     val zero = Centis(0)
+  }
+
+  implicit class CentisScalar(val scalar: Int) extends AnyVal {
+    def *(o: Centis) = o * scalar
   }
 
   def apply(value: Long): Centis = Centis {

--- a/src/main/scala/Clock.scala
+++ b/src/main/scala/Clock.scala
@@ -101,12 +101,7 @@ case class Clock(
   def berserked(c: Color) = players(c).berserk
   def lag(c: Color) = players(c).lag.avgLag
 
-  def avgLagComp = {
-    val lag1 = players.white.lag
-    val lag2 = players.black.lag
-    val lagSteps = lag1.lagSteps + lag2.lagSteps
-    lagSteps > 0 option ((lag1.totalComp + lag2.totalComp) / lagSteps)
-  }
+  def avgLagComp = players map { _.lag.avgLagComp }
 
   // Lowball estimate of next move's lag comp for UI butter.
   def lagCompEstimate(c: Color) = players(c).lag.lowEstimate

--- a/src/main/scala/DecayingStats.scala
+++ b/src/main/scala/DecayingStats.scala
@@ -1,14 +1,15 @@
 package chess
 
+trait DecayingRecorder {
+  def record(value: Float): DecayingStats
+}
+
 final case class DecayingStats(
     mean: Float,
     deviation: Float,
     decay: Float
-) {
-  def record[T](values: Traversable[T])(implicit n: Numeric[T]): DecayingStats =
-    values.foldLeft(this) { (s, v) => s record n.toFloat(v) }
-
-  def record(value: Float) = {
+) extends DecayingRecorder {
+  def record(value: Float): DecayingStats = {
     val delta = mean - value
 
     copy(
@@ -16,13 +17,17 @@ final case class DecayingStats(
       deviation = decay * deviation + (1 - decay) * math.abs(delta)
     )
   }
+
+  def record[T](values: Traversable[T])(implicit n: Numeric[T]): DecayingStats =
+    values.foldLeft(this) { (s, v) => s record n.toFloat(v) }
 }
 
 object DecayingStats {
-  def empty(deviation: Float, decay: Float = 0.9f)(value: Float) =
-    DecayingStats(
+  def empty(deviation: Float, decay: Float) = new DecayingRecorder {
+    def record(value: Float) = DecayingStats(
       mean = value,
       deviation = deviation,
       decay = decay
     )
+  }
 }

--- a/src/main/scala/Game.scala
+++ b/src/main/scala/Game.scala
@@ -50,11 +50,10 @@ case class Game(
   }
 
   private def applyClock(metrics: MoveMetrics, gameActive: Boolean) = clock.map { c =>
-    val newC = c.step(metrics, gameActive) getOrElse {
-      if (turns - startedAtTurn == 1) c.switch.start
-      else c.switch
+    {
+      val newC = c.step(metrics, gameActive)
+      if (turns - startedAtTurn == 1) newC.start else newC
     }
-    if (gameActive) newC else newC.hardStop
   }
 
   def apply(uci: Uci.Move): Valid[(Game, Move)] = apply(uci.orig, uci.dest, uci.promotion)

--- a/src/main/scala/LagTracker.scala
+++ b/src/main/scala/LagTracker.scala
@@ -24,9 +24,9 @@ final case class LagTracker(
   def recordLag(lag: Centis) =
     copy(history = history.record((lag atMost quota).centis))
 
-  def avgLagComp = lagSteps > 0 option totalComp / lagSteps
+  def avgLagComp = totalComp / lagSteps
 
-  def avgLag = lagSteps > 0 option totalLag / lagSteps
+  def avgLag = totalLag / lagSteps
 
   def lowEstimate = history match {
     case h: DecayingStats => {

--- a/src/main/scala/LagTracker.scala
+++ b/src/main/scala/LagTracker.scala
@@ -1,43 +1,50 @@
 package chess
 
-case class LagTracker(
+final case class LagTracker(
     quotaGain: Centis,
     quota: Centis,
     quotaMax: Centis,
-    history: Option[DecayingStats] = None
+    history: DecayingRecorder,
+    totalComp: Centis = Centis(0),
+    totalLag: Centis = Centis(0),
+    lagSteps: Int = 0
 ) {
   def onMove(lag: Centis) = {
-    val lagComp = lag.nonNeg atMost quota
+    val comp = lag atMost quota
 
-    (lagComp, copy(
-      quota = (quota + quotaGain - lagComp) atMost quotaMax,
-      history = Some(history.fold(
-        DecayingStats(
-          mean = lagComp.centis,
-          deviation = 5f,
-          decay = 0.9f
-        )
-      ) { _.record(lagComp.centis) })
+    (comp, copy(
+      quota = (quota + quotaGain - comp) atMost quotaMax,
+      history = history.record(comp.centis),
+      totalComp = totalComp + comp,
+      totalLag = totalLag + lag,
+      lagSteps = lagSteps + 1
     ))
   }
 
-  def estimate = history.map { h => Centis(h.mean.toInt) }
+  def recordLag(lag: Centis) =
+    copy(history = history.record((lag atMost quota).centis))
 
-  def lowEstimate = history.map { h =>
-    {
+  def avgLagComp = lagSteps > 0 option totalComp / lagSteps
+
+  def avgLag = lagSteps > 0 option totalLag / lagSteps
+
+  def lowEstimate = history match {
+    case h: DecayingStats => {
       val c = h.mean - Math.max(h.deviation, 2f)
-      Centis(c.toInt max 0) atMost quota
+      Some(Centis(c.toInt).nonNeg atMost quota)
     }
+    case _ => None
   }
 }
 
 object LagTracker {
-  def forClock(config: Clock.Config) = {
+  def init(config: Clock.Config) = {
     val quotaGain = Centis(config.estimateTotalSeconds max 50 min 100)
     LagTracker(
       quotaGain = quotaGain,
       quota = quotaGain * 2,
-      quotaMax = quotaGain * 5
+      quotaMax = quotaGain * 5,
+      history = DecayingStats.empty(deviation = 5f, decay = 0.9f)
     )
   }
 }

--- a/src/test/scala/ClockTest.scala
+++ b/src/test/scala/ClockTest.scala
@@ -46,7 +46,7 @@ class ClockTest extends ChessTest {
 
     def clockStep(clock: Clock, wait: Int, lags: Int*) = {
       (lags.foldLeft(clock) { (clk, lag) =>
-        (advance(clk.step().get, wait + lag) step durOf(lag)).get
+        advance(clk.step(), wait + lag) step durOf(lag)
       } remainingTime Black).centis
     }
 
@@ -54,8 +54,8 @@ class ClockTest extends ChessTest {
     def clockStep600(w: Int, l: Int*) = clockStep(fakeClock600, w, l: _*)
 
     def clockStart(lag: Int) = {
-      val clock = fakeClock60.step().get
-      ((clock step durOf(lag)).get remainingTime White).centis
+      val clock = fakeClock60.step()
+      ((clock step durOf(lag)) remainingTime White).centis
     }
 
     "start" in {


### PR DESCRIPTION
- Move clock logic from Game into Clock.
- Record avg lag comp and avg lag for reporting purposes.
- Avg lag comp will be stored in the new clock storage to improve
  accuracy of game replay mode.
- Record lag metrics on move 1, so that clock delays are more
  accurate and valid even for move 2.
- Use scalaz Monoid to simplify some code.