### PR TITLE
Reduce bullet lag comp

### DIFF
--- a/src/main/scala/LagTracker.scala
+++ b/src/main/scala/LagTracker.scala
@@ -39,11 +39,15 @@ final case class LagTracker(
 
 object LagTracker {
   def init(config: Clock.Config) = {
-    val quotaGain = Centis(config.estimateTotalSeconds max 50 min 100)
+    val quotaGain = Centis(config.estimateTotalSeconds match {
+      case i if i >= 140 => 100
+      case i if i <= 20 => 40
+      case i => i / 2 + 30
+    })
     LagTracker(
       quotaGain = quotaGain,
-      quota = quotaGain * 2,
-      quotaMax = quotaGain * 5,
+      quota = quotaGain * 3,
+      quotaMax = quotaGain * 6,
       history = EmptyDecayingStats(deviation = 5f, decay = 0.9f)
     )
   }

--- a/src/test/scala/ClockTest.scala
+++ b/src/test/scala/ClockTest.scala
@@ -78,7 +78,7 @@ class ClockTest extends ChessTest {
         clockStep600(0, 20) must_== 600 * 100
       }
       "premove, big lag" in {
-        clockStep600(0, 300) must_== 599 * 100
+        clockStep600(0, 400) must_== 599 * 100
       }
       "1s move, no lag" in {
         clockStep600(100, 0) must_== 599 * 100
@@ -87,7 +87,7 @@ class ClockTest extends ChessTest {
         clockStep600(100, 20) must_== 599 * 100
       }
       "1s move, big lag" in {
-        clockStep600(100, 300) must_== 598 * 100
+        clockStep600(100, 400) must_== 598 * 100
       }
     }
 
@@ -96,21 +96,21 @@ class ClockTest extends ChessTest {
         clockStep600(0, 0, 0) must_== 600 * 100
       }
       "medium lag x2" in {
-        clockStep600(0, 300, 300) must_== 597 * 100
+        clockStep600(0, 300, 300) must_== 598 * 100
       }
       "no -> medium lag" in {
         clockStep600(0, 0, 300) must_== 600 * 100
       }
       "no x8 -> big lag" in {
-        clockStep600(0, 0, 0, 0, 0, 0, 0, 0, 0, 700) must_== 598 * 100
+        clockStep600(0, 0, 0, 0, 0, 0, 0, 0, 0, 700) must_== 599 * 100
       }
 
       "no x5 -> big lag x2" in {
-        clockStep600(0, 0, 0, 0, 0, 0, 500, 500) must_== 596 * 100
+        clockStep600(0, 0, 0, 0, 0, 0, 500, 500) must_== 597 * 100
       }
 
       "no x5 -> big lag x3" in {
-        clockStep600(0, 0, 0, 0, 0, 0, 500, 500, 500) must_== 592 * 100
+        clockStep600(0, 0, 0, 0, 0, 0, 500, 500, 500) must_== 593 * 100
       }
     }
 
@@ -119,10 +119,10 @@ class ClockTest extends ChessTest {
         clockStep60(0, 0, 0) must_== 60 * 100
       }
       "no -> medium lag" in {
-        clockStep60(0, 0, 300) must_== 5880
+        clockStep60(0, 0, 300) must_== 5940
       }
       "no x4 -> big lag" in {
-        clockStep60(0, 0, 0, 0, 0, 700) must_== 5600
+        clockStep60(0, 0, 0, 0, 0, 700) must_== 5660
       }
     }
   }
@@ -131,7 +131,7 @@ class ClockTest extends ChessTest {
     "60s stall" in {
       val clock60 = advance(fakeClock60, 60 * 100)
 
-      clock60.minPending(White).centis must_== 5880
+      clock60.minPending(White).centis must_== 5820
       clock60.remainingTime(White).centis must_== 0
       clock60.outOfTime(Black, withGrace = true) must beFalse
       clock60.outOfTime(White, withGrace = true) must beFalse
@@ -140,7 +140,7 @@ class ClockTest extends ChessTest {
     "62s stall" in {
       val clock62 = advance(fakeClock60, 62 * 100)
 
-      clock62.minPending(White).centis must_== 6080
+      clock62.minPending(White).centis must_== 6020
       clock62.remainingTime(White).centis must_== 0
       clock62.outOfTime(White, withGrace = true) must beTrue
       clock62.outOfTime(White, withGrace = false) must beTrue


### PR DESCRIPTION
Some time controls reduced, such as ultra to .4 and hyper to .45.

Increase quota capacity based on graphana graphs which show players
sometimes spiking above the current quotas.