### PR TITLE
Fix insufficient material check when both players have bishops

### DIFF
--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -63,7 +63,7 @@ object InsufficientMatingMaterial {
     board rolesOf color filter (King !=) match {
       case Nil => true
       case List(Knight) => board rolesOf !color filter (King !=) filter (Queen !=) isEmpty
-      case List(Bishop) => (board rolesOf !color filter (King !=) filter (Queen !=) filter (Rook !=) filter (Bishop !=) isEmpty) || bishopsOnDifferentColor(board)
+      case List(Bishop) => (board rolesOf !color filter (King !=) filter (Queen !=) filter (Rook !=) filter (Bishop !=) isEmpty) && !bishopsOnDifferentColor(board)
       case _ => false
     }
 }

--- a/src/test/scala/VariantTest.scala
+++ b/src/test/scala/VariantTest.scala
@@ -24,6 +24,16 @@ class VariantTest extends ChessTest {
       }
     }
 
+    "Identify sufficient mating material when called (bishop)." in {
+      val position = "8/7B/K7/2b5/1k6/8/8/8 b - -"
+      val game = fenToGame(position, Standard)
+
+      game should beSuccess.like {
+        case game =>
+          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beFalse
+      }
+    }
+
     "Identify insufficient mating material when called (knight)." in {
       val position = "8/3k4/2q5/8/8/K1N5/8/8 b - -"
       val game = fenToGame(position, Standard)


### PR DESCRIPTION
Short-circuit evaluation in my previous commit applied incorrectly: if I have bishops (or a bishop) and my opponent has no knights or pawns, then I win unless all bishops are on the same color square