### PR TITLE
Validate antichess knight-versus-knight opposition draw

### DIFF
--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -17,8 +17,8 @@ object InsufficientMatingMaterial {
   def bishopsOnDifferentColor(board: Board) = {
     val notKingPieces = nonKingPieces(board)
 
-    def bishopsOnSameColor = notKingPieces.map(_._1.color).distinct.size == 1
-    def bishopsAreSameColor = notKingPieces.map(_._2.color).distinct.size == 1
+    lazy val bishopsOnSameColor = notKingPieces.map(_._1.color).distinct.size == 1
+    lazy val bishopsAreSameColor = notKingPieces.map(_._2.color).distinct.size == 1
 
     if (notKingPieces.exists(_._2.role != Bishop)) false
     else if (bishopsAreSameColor) notKingPieces.size < 3 || bishopsOnSameColor
@@ -46,24 +46,27 @@ object InsufficientMatingMaterial {
    */
   def apply(board: Board) = {
 
+    val kingsOnly = board.pieces forall { _._2 is King }
+
     lazy val notKingPieces = nonKingPieces(board)
 
-    def kingsOnly = board.pieces forall { _._2 is King }
+    lazy val singleKnight = notKingPieces.map(_._2.role) == List(Knight)
 
-    def bishopsOnSameColor =
+    lazy val bishopsOnSameColor =
       notKingPieces.map(_._2.role).distinct == List(Bishop) &&
         notKingPieces.map(_._1.color).distinct.size == 1
 
-    def singleKnight = notKingPieces.map(_._2.role) == List(Knight)
-
-    kingsOnly || bishopsOnSameColor || singleKnight
+    kingsOnly || singleKnight || bishopsOnSameColor
   }
 
-  def apply(board: Board, color: Color) =
-    board rolesOf color filter (King !=) match {
+  def apply(situation: Situation) = {
+    val board = situation.board
+    val color = situation.color
+    board rolesOf !color filter (King !=) match {
       case Nil => true
-      case List(Knight) => board rolesOf !color filter (King !=) filter (Queen !=) isEmpty
-      case List(Bishop) => (board rolesOf !color filter (King !=) filter (Queen !=) filter (Rook !=) filter (Bishop !=) isEmpty) && !bishopsOnDifferentColor(board)
+      case List(Knight) => board rolesOf color filter (King !=) filter (Queen !=) isEmpty
+      case List(Bishop) => (board rolesOf color filter (King !=) filter (Queen !=) filter (Rook !=) filter (Bishop !=) isEmpty) && !bishopsOnDifferentColor(board)
       case _ => false
     }
+  }
 }

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -37,12 +37,8 @@ case object Antichess extends Variant(
 
   override def specialEnd(situation: Situation) = {
     // The game ends with a win when one player manages to lose all their pieces or is in stalemate
-    situation.board.actorsOf(situation.color).isEmpty || situation.moves.isEmpty
+    situation.board.piecesOf(situation.color).isEmpty || situation.moves.isEmpty
   }
-
-  // In antichess, there is no checkmate condition therefore a player may only draw either by agreement
-  // , blockade or stalemate - a player always has sufficient material to win otherwise
-  override def insufficientWinningMaterial(board: Board, color: Color) = false
 
   // No player can win if the only remaining pieces are opposing bishops on different coloured
   // diagonals. There may be pawns that are incapable of moving and do not attack the right color
@@ -78,6 +74,16 @@ case object Antichess extends Variant(
     }
 
     bishopsAndPawns && drawnBishops
+  }
+
+  /**
+   * In antichess, knight versus knight is only winnable by one player
+   */
+  override def insufficientWinningMaterial(situation: Situation) = {
+    val board = situation.board
+    lazy val piecesOnSameColor = board.pieces.map(_._1.color).toStream.distinct.size == 1
+
+    board.rolesOf(White) == List(Knight) && board.rolesOf(Black) == List(Knight) && piecesOnSameColor
   }
 
   private def pawnNotAttackable(pawn: Actor, oppositeBishopColor: Color, board: Board) = {

--- a/src/main/scala/variant/Crazyhouse.scala
+++ b/src/main/scala/variant/Crazyhouse.scala
@@ -80,8 +80,8 @@ case object Crazyhouse extends Variant(
     super.checkmate(situation) && !canDropStuff(situation)
 
   // there is always sufficient mating material in Crazyhouse
-  override def insufficientWinningMaterial(board: Board, color: Color) = false
   override def insufficientWinningMaterial(board: Board) = false
+  override def insufficientWinningMaterial(situation: Situation) = false
 
   def possibleDrops(situation: Situation): Option[List[Pos]] =
     if (!situation.check) None

--- a/src/main/scala/variant/KingOfTheHill.scala
+++ b/src/main/scala/variant/KingOfTheHill.scala
@@ -20,8 +20,7 @@ case object KingOfTheHill extends Variant(
   /**
    * You only need a king to be able to win in this variant
    */
-  override def insufficientWinningMaterial(board: Board, color: Color) = false
-
   override def insufficientWinningMaterial(board: Board) = false
+  override def insufficientWinningMaterial(situation: Situation) = false
 }
 

--- a/src/main/scala/variant/RacingKings.scala
+++ b/src/main/scala/variant/RacingKings.scala
@@ -39,7 +39,7 @@ case object RacingKings extends Variant(
   override val initialFen = "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1"
 
   override def insufficientWinningMaterial(board: Board) = false
-  override def insufficientWinningMaterial(board: Board, color: Color) = false
+  override def insufficientWinningMaterial(situation: Situation) = false
 
   private def reachedGoal(board: Board, color: Color) =
     board.kingPosOf(color) exists (_.y == 8)

--- a/src/main/scala/variant/ThreeCheck.scala
+++ b/src/main/scala/variant/ThreeCheck.scala
@@ -24,13 +24,13 @@ case object ThreeCheck extends Variant(
     situation.color.fold(checks.white, checks.black) >= 3
   }
 
-  /**
-   * It's not possible to check or checkmate the opponent with only a king
-   */
-  override def insufficientWinningMaterial(board: Board, color: Color) =
-    board.rolesOf(color) == List(King)
-
   // When there is insufficient mating material, there is still potential to win by checking the opponent 3 times
   // by the variant ending. However, no players can check if there are only kings remaining
   override def insufficientWinningMaterial(board: Board) = board.actors.forall(_._2.piece is King)
+
+  /**
+   * It's not possible to check or checkmate the opponent with only a king
+   */
+  override def insufficientWinningMaterial(situation: Situation) =
+    situation.board.rolesOf(!situation.color) == List(King)
 }

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -113,11 +113,11 @@ abstract class Variant private[variant] (
   def insufficientWinningMaterial(board: Board) = InsufficientMatingMaterial(board)
 
   /**
-   * Returns true if the player of the given colour has insufficient material to win.
+   * Returns true if the player not on move has insufficient material to win.
    * This can be used to determine whether a player losing on time against a player
    * who doesn't have enough material to win should draw instead.
    */
-  def insufficientWinningMaterial(board: Board, color: Color) = InsufficientMatingMaterial(board, color)
+  def insufficientWinningMaterial(situation: Situation) = InsufficientMatingMaterial(situation)
 
   // Some variants have an extra effect on the board on a move. For example, in Atomic, some
   // pieces surrounding a capture explode

--- a/src/test/scala/AntichessVariantTest.scala
+++ b/src/test/scala/AntichessVariantTest.scala
@@ -271,6 +271,46 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       }
     }
 
+    "Be drawn on knight versus knight (opposite color)" in {
+      val positionString = "n7/8/8/8/8/8/8/N7 w - -"
+      val maybeGame = fenToGame(positionString, Antichess)
+
+      maybeGame must beSuccess.like {
+        case game =>
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+      }
+    }
+
+    "Be drawn on knight versus knight (opposite color)" in {
+      val positionString = "n7/8/8/8/8/8/8/N7 b - -"
+      val maybeGame = fenToGame(positionString, Antichess)
+
+      maybeGame must beSuccess.like {
+        case game =>
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+      }
+    }
+
+    "Not be drawn on knight versus knight (same color)" in {
+      val positionString = "n7/8/8/8/8/8/8/7N w - -"
+      val maybeGame = fenToGame(positionString, Antichess)
+
+      maybeGame must beSuccess.like {
+        case game =>
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
+      }
+    }
+
+    "Not be drawn on knight versus knight (same color)" in {
+      val positionString = "n7/8/8/8/8/8/8/7N b - -"
+      val maybeGame = fenToGame(positionString, Antichess)
+
+      maybeGame must beSuccess.like {
+        case game =>
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
+      }
+    }
+
     "Not be drawn on insufficient mating material" in {
       val positionString = "4K3/8/1b6/8/8/8/5B2/3k4 b - -"
       val maybeGame = fenToGame(positionString, Antichess)

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -357,7 +357,7 @@ class AtomicVariantTest extends ChessTest {
 
           moves must beSome.like {
             case queenMoves =>
-              queenMoves.pp.size must beEqualTo(queenMoves.toSet.pp.size)
+              queenMoves.size must beEqualTo(queenMoves.toSet.size)
           }
       }
 
@@ -377,7 +377,7 @@ class AtomicVariantTest extends ChessTest {
         ))
         successGame must beSuccess.like {
           case game =>
-            game.situation.pp.variantEnd must beTrue
+            game.situation.variantEnd must beTrue
         }
       }
       "from position" in {
@@ -403,19 +403,19 @@ class AtomicVariantTest extends ChessTest {
     }
 
     "Identify that a player does not have sufficient material to win when they only have a king" in {
-      val position = "8/8/8/8/7p/2k3q1/2K3P1/8 b - - 19 54"
-      val game = fenToGame(position, Atomic)
+      val position = "8/8/8/8/7p/2k3q1/2K3P1/8 b - -"
+      val originalGame = fenToGame(position, Atomic)
 
-      game must beSuccess.like {
+      originalGame must beSuccess.like {
         case game =>
           game.situation.end must beFalse
       }
 
-      val drawGame = game flatMap (_.playMoves(Pos.G3 -> Pos.G2))
+      val newGame = originalGame flatMap (_.playMoves(Pos.G3 -> Pos.G2, Pos.C2 -> Pos.D2))
 
-      drawGame must beSuccess.like {
+      newGame must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.White) must beTrue
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
 
     }

--- a/src/test/scala/AutodrawTest.scala
+++ b/src/test/scala/AutodrawTest.scala
@@ -16,7 +16,7 @@ class AutodrawTest extends ChessTest {
       }
       "opened" in {
         makeGame.playMoves(E2 -> E4, C7 -> C5, C2 -> C3, D7 -> D5, E4 -> D5) map { g =>
-          g.board.autoDraw
+          g.situation.autoDraw
         } must beSuccess(false)
       }
       "two kings" in {
@@ -66,13 +66,13 @@ K   bB""".autoDraw must_== false
       }
       "opened" in {
         makeGame.playMoves(E2 -> E4, C7 -> C5, C2 -> C3, D7 -> D5, E4 -> D5) map { g =>
-          g.board.autoDraw
+          g.situation.autoDraw
         } must beSuccess(false)
       }
       "tons of pointless moves" in {
         val moves = List.fill(30)(List(B1 -> C3, B8 -> C6, C3 -> B1, C6 -> B8))
         makeGame.playMoves(moves.flatten: _*) must beSuccess.like {
-          case g => g.board.autoDraw must_== true
+          case g => g.situation.autoDraw must_== true
         }
       }
     }

--- a/src/test/scala/CrazyhouseVariantTest.scala
+++ b/src/test/scala/CrazyhouseVariantTest.scala
@@ -43,7 +43,7 @@ class CrazyhouseVariantTest extends ChessTest {
       "tons of pointless moves but shouldn't apply 50-moves" in {
         val moves = List.fill(30)(List(B1 -> C3, B8 -> C6, C3 -> B1, C6 -> B8))
         Game(Crazyhouse).playMoves(moves.flatten: _*) must beSuccess.like {
-          case g => g.board.autoDraw must beFalse
+          case g => g.situation.autoDraw must beFalse
         }
       }
       "from prod should 3fold" in {
@@ -63,7 +63,7 @@ class CrazyhouseVariantTest extends ChessTest {
         val game = {
           fenToGame(fenPosition, Crazyhouse).toOption err "error"
         }
-        game.board.autoDraw must beFalse
+        game.situation.autoDraw must beFalse
       }
     }
     "prod 50 games accumulate hash" in {

--- a/src/test/scala/HordeVariantTest.scala
+++ b/src/test/scala/HordeVariantTest.scala
@@ -12,7 +12,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beFalse
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
       }
     }
 
@@ -22,7 +22,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
     }
 
@@ -32,7 +32,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.black) must beFalse
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
       }
     }
 
@@ -42,7 +42,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
     }
 
@@ -52,7 +52,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.black) must beFalse
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
       }
     }
 
@@ -62,7 +62,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
     }
 
@@ -72,7 +72,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.black) must beFalse
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
       }
     }
 
@@ -82,7 +82,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beFalse
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
       }
     }
 
@@ -92,7 +92,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board) must beTrue
+          game.situation.board.autoDraw must beTrue
       }
     }
 
@@ -102,7 +102,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board) must beTrue
+          game.situation.board.autoDraw must beTrue
       }
     }
 
@@ -112,7 +112,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board) must beFalse
+          game.situation.board.autoDraw must beFalse
       }
     }
   }

--- a/src/test/scala/VariantTest.scala
+++ b/src/test/scala/VariantTest.scala
@@ -20,7 +20,7 @@ class VariantTest extends ChessTest {
 
       game should beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
     }
 
@@ -30,7 +30,7 @@ class VariantTest extends ChessTest {
 
       game should beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beFalse
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
       }
     }
 
@@ -40,7 +40,7 @@ class VariantTest extends ChessTest {
 
       game should beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
     }
   }

--- a/src/test/scala/format/ForsythTest.scala
+++ b/src/test/scala/format/ForsythTest.scala
@@ -159,7 +159,7 @@ class ForsythTest extends ChessTest {
           case s => s.situation.board.history.lastMove must_== Some(Uci.Move(Pos.F7, Pos.F5))
         }
       }
-      "last move (for en passant in Pretrov's defense)" in {
+      "last move (for en passant in Petrov's defense)" in {
         f <<< "rnbqkb1r/ppp2ppp/8/3pP3/3Qn3/5N2/PPP2PPP/RNB1KB1R w KQkq d6 0 6" must beSome.like {
           case s => s.situation.board.history.lastMove must_== Some(Uci.Move(Pos.D7, Pos.D5))
         }


### PR DESCRIPTION
In antichess knight-versus-knight endgames the player having the opposition cannot lose (and there is no way to lose the opposition).

Getting visibility to `situation.color` required refactoring `InsufficientMatingMaterial(Board, Color)` into `InsufficientMatingMaterial(Situation)`, which works well since consumers only care whether the player *not* on move has sufficient material to win!