### PR TITLE
test on openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ notifications:
 
 # https://docs.travis-ci.com/user/languages/java/#Testing-Against-Multiple-JDKs
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 before_cache:


### PR DESCRIPTION
I noticed were still testing on oraclejdk8. Might as well use what we're actually running on prod these days.