### PR TITLE
Re-word antichess "title"

### DIFF
--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -8,7 +8,7 @@ case object Antichess extends Variant(
   key = "antichess",
   name = "Antichess",
   shortName = "Anti",
-  title = "Lose all your pieces (or reach a stalemate) to win the game.",
+  title = "Lose all your pieces (or get stalemated) to win the game.",
   standardInitialPosition = true
 ) {
 


### PR DESCRIPTION
Someone made the comment to me that "reach a stalemate" means that "the stalemating player wins" rather than "the stalemated player wins". Although that's not how I ever interpreted it, he has a good point that it's not too clear. This edit removes any ambiguity from the title.