### PR TITLE
Fix opposite-colored bishop with other pieces validation #163

### DIFF
--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -42,12 +42,12 @@ object InsufficientMatingMaterial {
   def apply(board: Board, color: Color) = {
 
     val kingsAndMinorsOnlyOfColor = board.piecesOf(color) forall { p => (p._2 is King) || (p._2 is Bishop) || (p._2 is Knight) }
-    lazy val rolesOfColor = board.piecesOf(color) map { _._2.role }
+    lazy val nonKingRolesOfColor = board rolesOf color filter (King !=)
     lazy val rolesOfOpponentColor = board rolesOf !color
 
-    kingsAndMinorsOnlyOfColor && ((rolesOfColor toList).distinct filter (King !=) match {
+    kingsAndMinorsOnlyOfColor && ((nonKingRolesOfColor toList).distinct match {
       case Nil => true
-      case List(Knight) => (rolesOfColor.size == 2) && (rolesOfOpponentColor filter (King !=) filter (Queen !=) isEmpty)
+      case List(Knight) => (nonKingRolesOfColor.size == 1) && (rolesOfOpponentColor filter (King !=) filter (Queen !=) isEmpty)
       case List(Bishop) => !(rolesOfOpponentColor.exists(r => r == Knight || r == Pawn) || bishopsOnOppositeColors(board))
       case _ => false
     })

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -8,14 +8,17 @@ package chess
  */
 object InsufficientMatingMaterial {
 
-  def nonKingPieces(board: Board) = board.pieces.filter(_._2.role != King).toList
+  def nonKingPieces(board: Board) = board.pieces filter (_._2.role != King)
+
+  def bishopsOnOppositeColors(board: Board) =
+    (board.pieces filter (_._2.role == Bishop) map (_._1.color) toList).distinct.size == 2
 
   /**
    * Returns true when remaining non-King pieces are only bishops that cannot
    * capture each other and cannot checkmate
    */
   def bishopsOnDifferentColor(board: Board) = {
-    val notKingPieces = nonKingPieces(board)
+    val notKingPieces = nonKingPieces(board) toList
 
     def bishopsOnSameColor = notKingPieces.map(_._1.color).distinct.size == 1
     def bishopsAreSameColor = notKingPieces.map(_._2.color).distinct.size == 1
@@ -46,24 +49,22 @@ object InsufficientMatingMaterial {
    */
   def apply(board: Board) = {
 
-    lazy val notKingPieces = nonKingPieces(board)
+    val notKingPieces = nonKingPieces(board)
 
-    def kingsOnly = board.pieces forall { _._2 is King }
-
-    def bishopsOnSameColor =
-      notKingPieces.map(_._2.role).distinct == List(Bishop) &&
-        notKingPieces.map(_._1.color).distinct.size == 1
-
-    def singleKnight = notKingPieces.map(_._2.role) == List(Knight)
-
-    kingsOnly || bishopsOnSameColor || singleKnight
+    (notKingPieces map (_._2.role) toList).distinct match {
+      case Nil => true
+      case List(Knight) => notKingPieces.size < 2
+      case List(Bishop) => !bishopsOnOppositeColors(board)
+      case _ => false
+    }
   }
 
   def apply(board: Board, color: Color) =
+
     board rolesOf color filter (King !=) match {
       case Nil => true
       case List(Knight) => board rolesOf !color filter (King !=) filter (Queen !=) isEmpty
-      case List(Bishop) => (board rolesOf !color filter (King !=) filter (Queen !=) filter (Rook !=) filter (Bishop !=) isEmpty) && !bishopsOnDifferentColor(board)
+      case List(Bishop) => !(board.rolesOf(!color).exists(r => r == Knight || r == Pawn) || bishopsOnOppositeColors(board))
       case _ => false
     }
 }

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -42,11 +42,12 @@ object InsufficientMatingMaterial {
   def apply(board: Board, color: Color) = {
 
     val kingsAndMinorsOnlyOfColor = board.piecesOf(color) forall { p => (p._2 is King) || (p._2 is Bishop) || (p._2 is Knight) }
+    lazy val rolesOfColor = board.piecesOf(color) map { _._2.role }
     lazy val rolesOfOpponentColor = board rolesOf !color
 
-    kingsAndMinorsOnlyOfColor && ((board.piecesOf(color) map { _._2.role } toList).distinct filter (King !=) match {
+    kingsAndMinorsOnlyOfColor && ((rolesOfColor toList).distinct filter (King !=) match {
       case Nil => true
-      case List(Knight) => rolesOfOpponentColor filter (King !=) filter (Queen !=) isEmpty
+      case List(Knight) => (rolesOfColor.size == 2) && (rolesOfOpponentColor filter (King !=) filter (Queen !=) isEmpty)
       case List(Bishop) => !(rolesOfOpponentColor.exists(r => r == Knight || r == Pawn) || bishopsOnOppositeColors(board))
       case _ => false
     })

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -48,19 +48,13 @@ object InsufficientMatingMaterial {
    * being able to mate the other as informed by the traditional chess rules.
    */
   def apply(board: Board) = {
+    lazy val bishopsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Bishop) }
+    val minorsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Bishop) || (p._2 is Knight) }
 
-    val notKingPieces = nonKingPieces(board)
-
-    (notKingPieces map (_._2.role) toList).distinct match {
-      case Nil => true
-      case List(Knight) => notKingPieces.size < 2
-      case List(Bishop) => !bishopsOnOppositeColors(board)
-      case _ => false
-    }
+    minorsOnly && (board.pieces.size <= 3 || (bishopsOnly && !bishopsOnOppositeColors(board)))
   }
 
   def apply(board: Board, color: Color) =
-
     board rolesOf color filter (King !=) match {
       case Nil => true
       case List(Knight) => board rolesOf !color filter (King !=) filter (Queen !=) isEmpty

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -13,28 +13,6 @@ object InsufficientMatingMaterial {
   def bishopsOnOppositeColors(board: Board) =
     (board.pieces filter (_._2.role == Bishop) map (_._1.color) toList).distinct.size == 2
 
-  /**
-   * Returns true when remaining non-King pieces are only bishops that cannot
-   * capture each other and cannot checkmate
-   */
-  def bishopsOnDifferentColor(board: Board) = {
-    val notKingPieces = nonKingPieces(board) toList
-
-    def bishopsOnSameColor = notKingPieces.map(_._1.color).distinct.size == 1
-    def bishopsAreSameColor = notKingPieces.map(_._2.color).distinct.size == 1
-
-    if (notKingPieces.exists(_._2.role != Bishop)) false
-    else if (bishopsAreSameColor) notKingPieces.size < 3 || bishopsOnSameColor
-    else {
-      val whitePlayerBishops = notKingPieces.filter(_._2.color == Color.White)
-      val blackPlayerBishops = notKingPieces.filter(_._2.color == Color.Black)
-
-      !whitePlayerBishops.exists {
-        case (pos, _) => blackPlayerBishops.exists(_._1.color == pos.color)
-      }
-    }
-  }
-
   /*
    * Returns true if a pawn cannot progress forward because it is blocked by a pawn
    */

--- a/src/main/scala/StartingPosition.scala
+++ b/src/main/scala/StartingPosition.scala
@@ -97,7 +97,7 @@ object StartingPosition {
       StartingPosition("C27", "Vienna Game", "rnbqkbnr/pppp1ppp/8/4p3/4P3/2N5/PPPP1PPP/R1BQKBNR b KQkq - 2 2", "Vienna_Game", "1. e4 e5 2.  Nc3"),
       StartingPosition("C27", "Frankenstein-Dracula Variation", "rnbqkb1r/pppp1ppp/8/4p3/2B1n3/2N5/PPPP1PPP/R1BQK1NR w KQkq - 0 4", "Frankenstein-Dracula_Variation", "1. e4 e5 2. Nc3 Nf6 3. Bc4 Nxe4"),
       StartingPosition("C47", "Halloween Gambit", "r1bqkb1r/pppp1ppp/2n2n2/4N3/4P3/2N5/PPPP1PPP/R1BQKB1R b KQkq - 1 4", "Halloween_Gambit", "1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. Nxe5"),
-      StartingPosition("C20" , "King's Pawn Game: Wayward Queen Attack", "rnbqkbnr/pppp1ppp/8/4p2Q/4P3/8/PPPP1PPP/RNB1KBNR b KQkq - 1 2", "Danvers_Opening", "1. e4 e5 2. Qh5"),
+      StartingPosition("C20", "King's Pawn Game: Wayward Queen Attack", "rnbqkbnr/pppp1ppp/8/4p2Q/4P3/8/PPPP1PPP/RNB1KBNR b KQkq - 1 2", "Danvers_Opening", "1. e4 e5 2. Qh5"),
       StartingPosition("420", "Bongcloud Attack", "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPPKPPP/RNBQ1BNR b kq - 0 2", "Bong", "1. e4 e5 2. Ke2", false)
     )),
     Category("d4", List(

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -83,7 +83,7 @@ case object Atomic extends Variant(
   private def insufficientAtomicWinningMaterial(board: Board) = {
     val kingsAndBishopsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Bishop) }
     lazy val bishopsOnOppositeColors = InsufficientMatingMaterial.bishopsOnOppositeColors(board)
-    lazy val kingsAndMinorsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Rook) || (p._2 is Bishop) || (p._2 is Knight) }
+    lazy val kingsRooksAndMinorsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Rook) || (p._2 is Bishop) || (p._2 is Knight) }
     lazy val rookExists = board.pieces exists { _._2 is Rook }
 
     // Bishops of opposite color (no other pieces) endgames are dead drawn
@@ -91,7 +91,7 @@ case object Atomic extends Variant(
     if (board.count(White) >= 2 && board.count(Black) >= 2) kingsAndBishopsOnly && board.pieces.size <= 4 && bishopsOnOppositeColors
 
     // Queen, rook + any, bishop pair, or any 3 minor pieces can mate
-    else kingsAndMinorsOnly && !bishopsOnOppositeColors && board.pieces.size <= (if (rookExists) 3 else 4)
+    else kingsRooksAndMinorsOnly && !bishopsOnOppositeColors && board.pieces.size <= (if (rookExists) 3 else 4)
   }
 
   /*

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -66,6 +66,7 @@ case object Atomic extends Variant(
       move withAfter newBoard
     } else move
   }
+
   /**
    * The positions surrounding a given position on the board. Any square at the edge of the board has
    * less surrounding positions than the usual eight.
@@ -76,22 +77,21 @@ case object Atomic extends Variant(
   override def addVariantEffect(move: Move): Move = explodeSurroundingPieces(move)
 
   /**
-   * Since a king may walk into the path of another king, it is more difficult to win when your opponent only has a
-   * king left.
+   * Since kings cannot confine each other, if either player has only a king
+   * then either a queen or multiple pieces are required for checkmate.
    */
   private def insufficientAtomicWinningMaterial(board: Board) = {
-    val whiteActors = board.actorsOf(White)
-    val blackActors = board.actorsOf(Black)
-    val allActors = board.actors
-    lazy val allPieces = board.actors.values.map(_.piece).filter(_ isNot King)
+    val bishopsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Bishop) }
+    lazy val bishopsOnOppositeColors = InsufficientMatingMaterial.bishopsOnOppositeColors(board)
+    lazy val minorsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Rook) || (p._2 is Bishop) || (p._2 is Knight) }
+    lazy val rookExists = board.pieces exists { _._2 is Rook }
 
-    // One player must only have their king left
-    if (whiteActors.size != 1 && blackActors.size != 1) false
-    else {
-      // You can mate with a queen or a pawn that is later promoted a a queen, but not with just one of any other piece
-      // or with just a king
-      allPieces.size == 1 && !allPieces.exists(p => p.is(Queen) || p.is(Pawn)) || allActors.size == 2
-    }
+    // Bishops of opposite color (no other pieces) endgames are dead drawn
+    // except if either player has multiple bishops so a helpmate is possible
+    if (board.count(White) >= 2 && board.count(Black) >= 2) bishopsOnly && board.pieces.size <= 4 && bishopsOnOppositeColors
+
+    // Queen, rook + any, bishop pair, or any 3 minor pieces can mate
+    else minorsOnly && !bishopsOnOppositeColors && board.pieces.size <= (if (rookExists) 3 else 4)
   }
 
   /*
@@ -100,7 +100,7 @@ case object Atomic extends Variant(
    * We also look out for closed positions (pawns that cannot move and kings which cannot capture them.)
    */
   override def insufficientWinningMaterial(board: Board) = {
-    InsufficientMatingMaterial.bishopsOnDifferentColor(board) || insufficientAtomicWinningMaterial(board) || atomicClosedPosition(board)
+    insufficientAtomicWinningMaterial(board) || atomicClosedPosition(board)
   }
 
   /**

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -81,17 +81,17 @@ case object Atomic extends Variant(
    * then either a queen or multiple pieces are required for checkmate.
    */
   private def insufficientAtomicWinningMaterial(board: Board) = {
-    val bishopsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Bishop) }
+    val kingsAndBishopsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Bishop) }
     lazy val bishopsOnOppositeColors = InsufficientMatingMaterial.bishopsOnOppositeColors(board)
-    lazy val minorsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Rook) || (p._2 is Bishop) || (p._2 is Knight) }
+    lazy val kingsAndMinorsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Rook) || (p._2 is Bishop) || (p._2 is Knight) }
     lazy val rookExists = board.pieces exists { _._2 is Rook }
 
     // Bishops of opposite color (no other pieces) endgames are dead drawn
     // except if either player has multiple bishops so a helpmate is possible
-    if (board.count(White) >= 2 && board.count(Black) >= 2) bishopsOnly && board.pieces.size <= 4 && bishopsOnOppositeColors
+    if (board.count(White) >= 2 && board.count(Black) >= 2) kingsAndBishopsOnly && board.pieces.size <= 4 && bishopsOnOppositeColors
 
     // Queen, rook + any, bishop pair, or any 3 minor pieces can mate
-    else minorsOnly && !bishopsOnOppositeColors && board.pieces.size <= (if (rookExists) 3 else 4)
+    else kingsAndMinorsOnly && !bishopsOnOppositeColors && board.pieces.size <= (if (rookExists) 3 else 4)
   }
 
   /*

--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -74,7 +74,7 @@ case object Horde extends Variant(
   override def insufficientWinningMaterial(board: Board, color: Color): Boolean = {
     lazy val fortress = hordeClosedPosition(board) // costly function call
     if (color == Color.white) {
-      lazy val notKingPieces = InsufficientMatingMaterial.nonKingPieces(board)
+      lazy val notKingPieces = InsufficientMatingMaterial.nonKingPieces(board) toList
       val horde = board.piecesOf(Color.white)
       lazy val hordeBishopSquareColors = horde.filter(_._2.is(Bishop)).toList.map(_._1.color).distinct
       lazy val hordeRoles = horde.map(_._2.role)

--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -96,7 +96,7 @@ case object Horde extends Variant(
         }
       } else if ((hordeRoles.forall(_ == Bishop) && hordeBishopSquareColors.size == 1) && (armyBishops.size < 2 || (armyPawns.isEmpty && armyBishops.size == armyBishopSquareColors.size))) true
       else if ((horde.size == 2 && armyNonQueens.size <= 1) && (armyNonQueens.size == 0 || horde.forall(_._2.isMinor))) true
-      else if (notKingPieces.map(_._2.role).distinct == List(Bishop) && !InsufficientMatingMaterial.bishopsOnDifferentColor(board)) true
+      else if (notKingPieces.map(_._2.role).distinct == List(Bishop) && !InsufficientMatingMaterial.bishopsOnOppositeColors(board)) true
       else fortress
     } else fortress
   }

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -459,5 +459,109 @@ class AtomicVariantTest extends ChessTest {
           game.situation.end must beFalse
       }
     }
+
+    "Not draw inappropriately on three bishops (of both square colors)" in {
+      val position = "8/5k2/8/8/8/8/4pKB1/5B2 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on three bishops (of both square colors)" in {
+      val position = "8/5k2/8/8/8/8/4pKB1/6B1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on two bishops and a knight" in {
+      val position = "8/5k2/8/8/8/8/4pKB1/6N1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on two bishops and a knight" in {
+      val position = "8/5k2/8/8/8/8/4pKN1/6B1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on two knights and a bishop" in {
+      val position = "8/5k2/8/8/8/8/4pKN1/6N1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on three knights (of two colors)" in {
+      val position = "8/5k2/8/8/8/8/4pKN1/6N1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Knight.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on three knights (of two colors)" in {
+      val position = "8/5k2/8/8/8/8/4pKN1/6n1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Knight.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on three knights (of the same color)" in {
+      val position = "8/5k2/8/8/8/8/4pKn1/6n1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Knight.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
   }
 }

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -357,7 +357,7 @@ class AtomicVariantTest extends ChessTest {
 
           moves must beSome.like {
             case queenMoves =>
-              queenMoves.pp.size must beEqualTo(queenMoves.toSet.pp.size)
+              queenMoves.size must beEqualTo(queenMoves.toSet.size)
           }
       }
 
@@ -377,7 +377,7 @@ class AtomicVariantTest extends ChessTest {
         ))
         successGame must beSuccess.like {
           case game =>
-            game.situation.pp.variantEnd must beTrue
+            game.situation.variantEnd must beTrue
         }
       }
       "from position" in {

--- a/src/test/scala/AutodrawTest.scala
+++ b/src/test/scala/AutodrawTest.scala
@@ -152,5 +152,17 @@ K   bB""".autoDraw must_== false
           game.situation.end must beFalse
       }
     }
+    "on opposite bishops with queen" in {
+      val position = "8/8/3Q4/2bK4/B7/8/8/k7 b - - 0 67"
+      val game = fenToGame(position, Standard)
+      val newGame = game flatMap (_.playMove(
+        Pos.A1, Pos.B2
+      ))
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.autoDraw must beFalse
+          game.situation.end must beFalse
+      }
+    }
   }
 }

--- a/src/test/scala/AutodrawTest.scala
+++ b/src/test/scala/AutodrawTest.scala
@@ -49,10 +49,10 @@ K N    """.autoDraw must_== false
       k
 K r   B""".autoDraw must_== false
       }
-      "one bishop and one bishop of same colors" in {
+      "two bishops and one bishop of same colors" in {
         """
       k
-K   b B""".autoDraw must_== true
+K B b B""".autoDraw must_== true
       }
       "one bishop and one bishop of different colors" in {
         """
@@ -116,8 +116,8 @@ K   bB""".autoDraw must_== false
           game.situation.end must beFalse
       }
     }
-    "on bishop versus pawn" in {
-      val position = "1b5K/8/5k1P/8/8/8/8/8 b - - 0 40"
+    "on bishops versus pawn" in {
+      val position = "1b1b3K/8/5k1P/8/8/8/8/8 b - - 0 40"
       val game = fenToGame(position, Standard)
       val newGame = game flatMap (_.playMove(
         Pos.B8, Pos.E5

--- a/src/test/scala/AutodrawTest.scala
+++ b/src/test/scala/AutodrawTest.scala
@@ -128,6 +128,34 @@ K   bB""".autoDraw must_== false
           game.situation.end must beFalse
       }
     }
+    "on bishops versus queen" in {
+      val position = "b2b3K/8/5k1Q/8/8/8/8/8 b - -"
+      val game = fenToGame(position, Standard)
+      val newGame = game flatMap (_.playMove(
+        Pos.F6, Pos.E5
+      ))
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.autoDraw must beFalse
+          game.situation.end must beFalse
+          game.board.variant.insufficientWinningMaterial(game.board, White) must beFalse
+          game.board.variant.insufficientWinningMaterial(game.board, Black) must beFalse
+      }
+    }
+    "on bishops versus queen" in {
+      val position = "1b1b3K/8/5k1Q/8/8/8/8/8 b - -"
+      val game = fenToGame(position, Standard)
+      val newGame = game flatMap (_.playMove(
+        Pos.F6, Pos.E5
+      ))
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.autoDraw must beFalse
+          game.situation.end must beFalse
+          game.board.variant.insufficientWinningMaterial(game.board, White) must beFalse
+          game.board.variant.insufficientWinningMaterial(game.board, Black) must beTrue
+      }
+    }
     "on knight versus pawns" in {
       val position = "8/8/5N2/8/6p1/8/5K1p/7k w - - 0 37"
       val game = fenToGame(position, Standard)

--- a/src/test/scala/AutodrawTest.scala
+++ b/src/test/scala/AutodrawTest.scala
@@ -34,6 +34,11 @@ K      """.autoDraw must_== false
       k
 K     B""".autoDraw must_== true
       }
+      "one knight" in {
+        """
+      k
+K     N""".autoDraw must_== true
+      }
       "one bishop and one knight of different colors" in {
         """
       k
@@ -104,6 +109,16 @@ K   bB""".autoDraw must_== false
     }
   }
   "do not detect insufficient material" should {
+    "on two knights" in {
+      val position = "1n2k1n1/8/8/8/8/8/8/4K3 w - - 0 1"
+      fenToGame(position, Standard) must beSuccess.like {
+        case game =>
+          game.situation.autoDraw must beFalse
+          game.situation.end must beFalse
+          game.board.variant.insufficientWinningMaterial(game.board, White) must beTrue
+          game.board.variant.insufficientWinningMaterial(game.board, Black) must beFalse
+      }
+    }
     "on knight versus pawn" in {
       val position = "7K/5k2/7P/6n1/8/8/8/8 b - - 0 40"
       val game = fenToGame(position, Standard)


### PR DESCRIPTION
A player with only bishops can checkmate if the opponent has a knight (or a pawn), or if the position has bishops (of either color) on both color complexes.