### PR TITLE
Atomic closed position

### DIFF
--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -25,7 +25,7 @@ object InsufficientMatingMaterial {
    * Determines whether a board position is an automatic draw due to neither player
    * being able to mate the other as informed by the traditional chess rules.
    */
-  def apply(board: Board) = {
+  def apply(board: Board): Boolean = {
     lazy val kingsAndBishopsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Bishop) }
     val kingsAndMinorsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Bishop) || (p._2 is Knight) }
 
@@ -39,7 +39,7 @@ object InsufficientMatingMaterial {
    * King + bishop mates against king + any(bishop, knight, pawn)
    * King + bishop(s) versus king + bishop(s) depends upon bishop square colors
    */
-  def apply(situation: Situation) = {
+  def apply(situation: Situation): Boolean = {
     val board = situation.board
     val opponentColor = !situation.color
     val kingsAndMinorsOnlyOfOpponentColor = board.piecesOf(opponentColor) forall { p => (p._2 is King) || (p._2 is Bishop) || (p._2 is Knight) }
@@ -52,5 +52,13 @@ object InsufficientMatingMaterial {
       case List(Bishop) => !(rolesOfColor.exists(r => r == Knight || r == Pawn) || bishopsOnOppositeColors(board))
       case _ => false
     })
+  }
+
+  /*
+   * Determines whether a color (of a game in progress) has mating material
+   */
+  def apply(game: Game, color: Color): Boolean = {
+    if (game.situation.color != color) apply(game.situation)
+    else game.situation.moves.values forall { _ forall { move => apply(game.apply(move).situation) } }
   }
 }

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -13,13 +13,21 @@ object InsufficientMatingMaterial {
   def bishopsOnOppositeColors(board: Board) =
     (board.pieces collect { case (pos, Piece(_, Bishop)) => pos.color } toList).distinct.size == 2
 
+  def piecesOnOppositeColors(pieces: PieceMap) =
+    (pieces map { _._1.color } toList).distinct.size == 2
+
+  def bishopCanCaptureNonKing(board: Board) = {
+    board.pieces exists { b => (b._2 is Bishop) && (board.pieces exists { p => p._2.color != b._2.color && !p._2.is(King) && p._1.color == b._1.color }) }
+  }
+
   /*
    * Returns true if a pawn cannot progress forward because it is blocked by a pawn
    */
-  def pawnBlockedByPawn(pawn: Actor, board: Board) = pawn.moves.isEmpty && {
-    val blockingPosition = Actor.posAheadOfPawn(pawn.pos, pawn.piece.color)
-    blockingPosition.flatMap(board.actorAt(_)).exists(_.piece.is(Pawn))
-  }
+  def pawnBlockedByPawn(pawn: Actor, board: Board) =
+    pawn.moves.isEmpty && (Actor.posAheadOfPawn(pawn.pos, pawn.piece.color) match {
+      case Some(pos) => board.pieces(pos) is Pawn
+      case _ => false
+    })
 
   /*
    * Determines whether a color (of a game in progress) has mating material

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -33,14 +33,15 @@ object InsufficientMatingMaterial {
   }
 
   /*
-   * Determines whether a color does not have mating material. In general:
+   * Determines whether the color not on move has mating material. In general:
    * King by itself is not mating material
    * King + knight mates against king + any(rook, bishop, knight, pawn)
    * King + bishop mates against king + any(bishop, knight, pawn)
    * King + bishop(s) versus king + bishop(s) depends upon bishop square colors
    */
-  def apply(board: Board, color: Color) = {
-
+  def apply(situation: Situation) = {
+    val board = situation.board
+    val color = !situation.color
     val kingsAndMinorsOnlyOfColor = board.piecesOf(color) forall { p => (p._2 is King) || (p._2 is Bishop) || (p._2 is Knight) }
     lazy val nonKingRolesOfColor = board rolesOf color filter (King !=)
     lazy val rolesOfOpponentColor = board rolesOf !color

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -41,15 +41,15 @@ object InsufficientMatingMaterial {
    */
   def apply(situation: Situation) = {
     val board = situation.board
-    val color = !situation.color
-    val kingsAndMinorsOnlyOfColor = board.piecesOf(color) forall { p => (p._2 is King) || (p._2 is Bishop) || (p._2 is Knight) }
-    lazy val nonKingRolesOfColor = board rolesOf color filter (King !=)
-    lazy val rolesOfOpponentColor = board rolesOf !color
+    val opponentColor = !situation.color
+    val kingsAndMinorsOnlyOfOpponentColor = board.piecesOf(opponentColor) forall { p => (p._2 is King) || (p._2 is Bishop) || (p._2 is Knight) }
+    lazy val nonKingRolesOfOpponentColor = board rolesOf opponentColor filter (King !=)
+    lazy val rolesOfColor = board rolesOf situation.color
 
-    kingsAndMinorsOnlyOfColor && ((nonKingRolesOfColor toList).distinct match {
+    kingsAndMinorsOnlyOfOpponentColor && ((nonKingRolesOfOpponentColor toList).distinct match {
       case Nil => true
-      case List(Knight) => (nonKingRolesOfColor.size == 1) && (rolesOfOpponentColor filter (King !=) filter (Queen !=) isEmpty)
-      case List(Bishop) => !(rolesOfOpponentColor.exists(r => r == Knight || r == Pawn) || bishopsOnOppositeColors(board))
+      case List(Knight) => (nonKingRolesOfOpponentColor.size == 1) && (rolesOfColor filter (King !=) filter (Queen !=) isEmpty)
+      case List(Bishop) => !(rolesOfColor.exists(r => r == Knight || r == Pawn) || bishopsOnOppositeColors(board))
       case _ => false
     })
   }

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -58,7 +58,11 @@ object InsufficientMatingMaterial {
    * Determines whether a color (of a game in progress) has mating material
    */
   def apply(game: Game, color: Color): Boolean = {
-    if (game.situation.color != color) apply(game.situation)
-    else game.situation.moves.values forall { _ forall { move => apply(game.apply(move).situation) } }
+    if (game.situation.color != color) game.board.variant.insufficientWinningMaterial(game.situation)
+    else {
+      // Crazyhouse drop moves are not accounted for in game.situation.moves
+      val moves = game.situation.moves;
+      (!(moves isEmpty)) && (moves.values forall { _ forall { move => game.board.variant.insufficientWinningMaterial(game.apply(move).situation) } })
+    }
   }
 }

--- a/src/main/scala/Situation.scala
+++ b/src/main/scala/Situation.scala
@@ -31,6 +31,8 @@ case class Situation(board: Board, color: Color) {
 
   def autoDraw: Boolean = board.autoDraw || board.variant.specialDraw(this)
 
+  def insufficientWinningMaterial: Boolean = board.variant insufficientWinningMaterial this
+
   lazy val threefoldRepetition: Boolean = board.history.threefoldRepetition
 
   def variantEnd = board.variant specialEnd this

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -48,28 +48,27 @@ case object Antichess extends Variant(
   // diagonals. There may be pawns that are incapable of moving and do not attack the right color
   // of square to allow the player to force their opponent to capture their bishop, also resulting in a draw
   override def insufficientWinningMaterial(board: Board) = {
-    val actors = board.actors
+    val pieces = board.pieces
 
     // Exit early if we are not in a situation with only bishops and pawns
-    val bishopsAndPawns = actors.forall(act => act._2.piece.is(Bishop) || act._2.piece.is(Pawn)) &&
-      actors.find(_._2.piece.is(Bishop)).isDefined
+    val bishopsAndPawns = pieces.forall(p => p._2.is(Bishop) || p._2.is(Pawn)) &&
+      pieces.find(_._2.is(Bishop)).isDefined
 
-    lazy val drawnBishops = actors.values.partition(_.color == White) match {
+    lazy val drawnBishops = board.pieces.partition(_._2.color == White) match {
       case (whitePieces, blackPieces) =>
-        val whiteBishops = whitePieces.filter(_.piece.is(Bishop))
-        val blackBishops = blackPieces.filter(_.piece.is(Bishop))
-        lazy val whitePawns = whitePieces.filter(_.piece.is(Pawn))
-        lazy val blackPawns = blackPieces.filter(_.piece.is(Pawn))
+        val whiteBishops = whitePieces.filter(_._2.is(Bishop))
+        val blackBishops = blackPieces.filter(_._2.is(Bishop))
+        lazy val whitePawns = board.actorsOf(White).filter(_.piece.is(Pawn))
+        lazy val blackPawns = board.actorsOf(Black).filter(_.piece.is(Pawn))
 
         // We consider the case where a player has two bishops on the same diagonal after promoting by using .distinct.
-        // If after applying .distinct the size of the list is greater than one, then the player has bishops on both
-        // colours
-        if (whiteBishops.map(_.pos.color)(breakOut).distinct.size != 1 ||
-          blackBishops.map(_.pos.color)(breakOut).distinct.size != 1) false
+        // If after applying .distinct the size of the list is greater than one, then the player has bishops on both colours
+        if (whiteBishops.map(_._1.color)(breakOut).distinct.size != 1 ||
+          blackBishops.map(_._1.color)(breakOut).distinct.size != 1) false
         else {
           for {
-            whiteSquareColor <- whiteBishops.headOption map (_.pos.color)
-            blackSquareColor <- blackBishops.headOption map (_.pos.color)
+            whiteSquareColor <- whiteBishops.headOption map (_._1.color)
+            blackSquareColor <- blackBishops.headOption map (_._1.color)
           } yield {
             whiteSquareColor != blackSquareColor && whitePawns.forall(pawnNotAttackable(_, blackSquareColor, board)) &&
               blackPawns.forall(pawnNotAttackable(_, whiteSquareColor, board))

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -37,7 +37,7 @@ case object Antichess extends Variant(
 
   override def specialEnd(situation: Situation) = {
     // The game ends with a win when one player manages to lose all their pieces or is in stalemate
-    situation.board.actorsOf(situation.color).isEmpty || situation.moves.isEmpty
+    situation.board.piecesOf(situation.color).isEmpty || situation.moves.isEmpty
   }
 
   // In antichess, there is no checkmate condition therefore a player may only draw either by agreement

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -58,8 +58,8 @@ case object Antichess extends Variant(
       case (whitePieces, blackPieces) =>
         val whiteBishops = whitePieces.filter(_._2.is(Bishop))
         val blackBishops = blackPieces.filter(_._2.is(Bishop))
-        lazy val whitePawns = board.actorsOf(White).filter(_.piece.is(Pawn))
-        lazy val blackPawns = board.actorsOf(Black).filter(_.piece.is(Pawn))
+        lazy val whitePawns = board.piecesOf(White).filter(_._2.is(Pawn)).map { case (pos, piece) => Actor(piece, pos, board) }
+        lazy val blackPawns = board.piecesOf(Black).filter(_._2.is(Pawn)).map { case (pos, piece) => Actor(piece, pos, board) }
 
         // We consider the case where a player has two bishops on the same diagonal after promoting by using .distinct.
         // If after applying .distinct the size of the list is greater than one, then the player has bishops on both colours

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -42,7 +42,7 @@ case object Antichess extends Variant(
 
   // In antichess, there is no checkmate condition therefore a player may only draw either by agreement
   // , blockade or stalemate - a player always has sufficient material to win otherwise
-  override def insufficientWinningMaterial(board: Board, color: Color) = false
+  override def insufficientWinningMaterial(situation: Situation) = false
 
   // No player can win if the only remaining pieces are opposing bishops on different coloured
   // diagonals. There may be pawns that are incapable of moving and do not attack the right color

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -116,8 +116,8 @@ case object Atomic extends Variant(
    * a piece in the opponent's king's proximity. On the other hand, a king alone or a king with
    * immobile pawns is not sufficient material to win with.
    */
-  override def insufficientWinningMaterial(board: Board, color: Color) =
-    board.rolesOf(color) == List(King)
+  override def insufficientWinningMaterial(situation: Situation) =
+    situation.board.rolesOf(!situation.color) == List(King)
 
   /** Atomic chess has a special end where a king has been killed by exploding with an adjacent captured piece */
   override def specialEnd(situation: Situation) = situation.board.kingPos.size != 2

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -99,9 +99,8 @@ case object Atomic extends Variant(
    * mate would be not be very likely. Additionally, a player can only mate another player with sufficient material.
    * We also look out for closed positions (pawns that cannot move and kings which cannot capture them.)
    */
-  override def insufficientWinningMaterial(board: Board) = {
+  override def insufficientWinningMaterial(board: Board) =
     insufficientAtomicWinningMaterial(board) || atomicClosedPosition(board)
-  }
 
   /**
    * Since a king cannot capture, K + P vs K + P where none of the pawns can move is an automatic draw
@@ -111,8 +110,7 @@ case object Atomic extends Variant(
     lazy val whiteBishops = board.pieces filter { p => (p._2.color == White) && (p._2 is Bishop) }
     lazy val blackBishops = board.pieces filter { p => (p._2.color == Black) && (p._2 is Bishop) }
     lazy val cornerPawn = board.pieces exists { p => (p._1 == Pos.A2 || p._1 == Pos.H2 || p._1 == Pos.A7 || p._1 == Pos.H7) && (p._2 is Pawn) }
-    lazy val unblockedPawns = board.pieces exists { p => (p._2 is Pawn) && !InsufficientMatingMaterial.pawnBlockedByPawn(Actor(p._2, p._1, board), board)
-    }
+    lazy val unblockedPawns = board.pieces exists { p => (p._2 is Pawn) && !InsufficientMatingMaterial.pawnBlockedByPawn(Actor(p._2, p._1, board), board) }
 
     kingsAndBishopsAndPawnsOnly &&
       (whiteBishops.isEmpty || blackBishops.isEmpty || whiteBishops.size + blackBishops.size < 3) &&
@@ -127,21 +125,23 @@ case object Atomic extends Variant(
    * a piece in the opponent's king's proximity. On the other hand, a king alone or a king with
    * immobile pawns is not sufficient material to win with.
    */
-  override def insufficientWinningMaterial(situation: Situation) = {
+  override def insufficientWinningMaterial(situation: Situation) =
+    situation.board.rolesOf(!situation.color) == List(King) || atomicClosedPosition(situation)
+
+  private def atomicClosedPosition(situation: Situation) = {
     val board = situation.board
-    lazy val kingsAndBishopsAndPawnsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Bishop) || (p._2 is Pawn) }
+    val kingsAndBishopsAndPawnsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Bishop) || (p._2 is Pawn) }
     lazy val whiteBishops = board.pieces filter { p => (p._2.color == White) && (p._2 is Bishop) }
     lazy val blackBishops = board.pieces filter { p => (p._2.color == Black) && (p._2 is Bishop) }
     lazy val corneredByPawn = board.pieces exists { p => (if (situation.color == White) (p._1 == Pos.A7 || p._1 == Pos.H7) else (p._1 == Pos.A2 || p._1 == Pos.H2)) && (p._2 is Pawn) }
-    lazy val unblockedPawns = board.pieces exists { p => (p._2 is Pawn) && !InsufficientMatingMaterial.pawnBlockedByPawn(Actor(p._2, p._1, board), board)
-    }
+    lazy val unblockedPawns = board.pieces exists { p => (p._2 is Pawn) && !InsufficientMatingMaterial.pawnBlockedByPawn(Actor(p._2, p._1, board), board) }
 
-    board.rolesOf(!situation.color) == List(King) || (kingsAndBishopsAndPawnsOnly &&
+    kingsAndBishopsAndPawnsOnly &&
       (whiteBishops.isEmpty || blackBishops.isEmpty || whiteBishops.size + blackBishops.size < 3) &&
       !InsufficientMatingMaterial.piecesOnOppositeColors(whiteBishops) &&
       !InsufficientMatingMaterial.piecesOnOppositeColors(blackBishops) &&
       !InsufficientMatingMaterial.bishopCanCaptureNonKing(board) &&
-      !((corneredByPawn && !whiteBishops.isEmpty && !blackBishops.isEmpty) || unblockedPawns))
+      !((corneredByPawn && !whiteBishops.isEmpty && !blackBishops.isEmpty) || unblockedPawns)
   }
 
   /** Atomic chess has a special end where a king has been killed by exploding with an adjacent captured piece */

--- a/src/main/scala/variant/Crazyhouse.scala
+++ b/src/main/scala/variant/Crazyhouse.scala
@@ -80,8 +80,8 @@ case object Crazyhouse extends Variant(
     super.checkmate(situation) && !canDropStuff(situation)
 
   // there is always sufficient mating material in Crazyhouse
-  override def insufficientWinningMaterial(board: Board, color: Color) = false
   override def insufficientWinningMaterial(board: Board) = false
+  override def insufficientWinningMaterial(situation: Situation) = false
 
   def possibleDrops(situation: Situation): Option[List[Pos]] =
     if (!situation.check) None

--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -71,7 +71,9 @@ case object Horde extends Variant(
    * Technically there are some positions where stalemate is unavoidable which
    * this method does not detect; however, such are trivial to premove.
    */
-  override def insufficientWinningMaterial(board: Board, color: Color): Boolean = {
+  override def insufficientWinningMaterial(situation: Situation): Boolean = {
+    val board = situation.board
+    val color = !situation.color
     lazy val fortress = hordeClosedPosition(board) // costly function call
     if (color == Color.white) {
       lazy val notKingPieces = InsufficientMatingMaterial.nonKingPieces(board) toList

--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -73,9 +73,9 @@ case object Horde extends Variant(
    */
   override def insufficientWinningMaterial(situation: Situation): Boolean = {
     val board = situation.board
-    val color = !situation.color
+    val opponentColor = !situation.color
     lazy val fortress = hordeClosedPosition(board) // costly function call
-    if (color == Color.white) {
+    if (opponentColor == Color.white) {
       lazy val notKingPieces = InsufficientMatingMaterial.nonKingPieces(board) toList
       val horde = board.piecesOf(Color.white)
       lazy val hordeBishopSquareColors = horde.filter(_._2.is(Bishop)).toList.map(_._1.color).distinct

--- a/src/main/scala/variant/KingOfTheHill.scala
+++ b/src/main/scala/variant/KingOfTheHill.scala
@@ -20,8 +20,7 @@ case object KingOfTheHill extends Variant(
   /**
    * You only need a king to be able to win in this variant
    */
-  override def insufficientWinningMaterial(board: Board, color: Color) = false
-
   override def insufficientWinningMaterial(board: Board) = false
+  override def insufficientWinningMaterial(situation: Situation) = false
 }
 

--- a/src/main/scala/variant/RacingKings.scala
+++ b/src/main/scala/variant/RacingKings.scala
@@ -39,7 +39,7 @@ case object RacingKings extends Variant(
   override val initialFen = "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1"
 
   override def insufficientWinningMaterial(board: Board) = false
-  override def insufficientWinningMaterial(board: Board, color: Color) = false
+  override def insufficientWinningMaterial(situation: Situation) = false
 
   private def reachedGoal(board: Board, color: Color) =
     board.kingPosOf(color) exists (_.y == 8)

--- a/src/main/scala/variant/ThreeCheck.scala
+++ b/src/main/scala/variant/ThreeCheck.scala
@@ -27,8 +27,8 @@ case object ThreeCheck extends Variant(
   /**
    * It's not possible to check or checkmate the opponent with only a king
    */
-  override def insufficientWinningMaterial(board: Board, color: Color) =
-    board.rolesOf(color) == List(King)
+  override def insufficientWinningMaterial(situation: Situation) =
+    situation.board.rolesOf(!situation.color) == List(King)
 
   // When there is insufficient mating material, there is still potential to win by checking the opponent 3 times
   // by the variant ending. However, no players can check if there are only kings remaining

--- a/src/main/scala/variant/ThreeCheck.scala
+++ b/src/main/scala/variant/ThreeCheck.scala
@@ -32,5 +32,5 @@ case object ThreeCheck extends Variant(
 
   // When there is insufficient mating material, there is still potential to win by checking the opponent 3 times
   // by the variant ending. However, no players can check if there are only kings remaining
-  override def insufficientWinningMaterial(board: Board) = board.actors.forall(_._2.piece is King)
+  override def insufficientWinningMaterial(board: Board) = board.pieces.values.forall(_ is King)
 }

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -117,7 +117,7 @@ abstract class Variant private[variant] (
    * This can be used to determine whether a player losing on time against a player
    * who doesn't have enough material to win should draw instead.
    */
-  def insufficientWinningMaterial(board: Board, color: Color) = InsufficientMatingMaterial(board, color)
+  def insufficientWinningMaterial(situation: Situation) = InsufficientMatingMaterial(situation)
 
   // Some variants have an extra effect on the board on a move. For example, in Atomic, some
   // pieces surrounding a capture explode

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -403,17 +403,17 @@ class AtomicVariantTest extends ChessTest {
     }
 
     "Identify that a player does not have sufficient material to win when they only have a king" in {
-      val position = "8/8/8/8/7p/2k3q1/2K3P1/8 b - -"
-      val originalGame = fenToGame(position, Atomic)
+      val position = "8/8/8/8/7p/2k4q/2K3P1/8 w - - 19 54"
+      val game = fenToGame(position, Atomic)
 
-      originalGame must beSuccess.like {
+      game must beSuccess.like {
         case game =>
           game.situation.end must beFalse
       }
 
-      val newGame = originalGame flatMap (_.playMoves(Pos.G3 -> Pos.G2, Pos.C2 -> Pos.D2))
+      val drawGame = game flatMap (_.playMoves(Pos.G2 -> Pos.H3))
 
-      newGame must beSuccess.like {
+      drawGame must beSuccess.like {
         case game =>
           game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
@@ -452,6 +452,110 @@ class AtomicVariantTest extends ChessTest {
       val game = fenToGame(position, Atomic)
       val newGame = game flatMap (_.playMove(
         Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on three bishops (of both square colors)" in {
+      val position = "8/5k2/8/8/8/8/4pKB1/5B2 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on three bishops (of both square colors)" in {
+      val position = "8/5k2/8/8/8/8/4pKB1/6B1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on two bishops and a knight" in {
+      val position = "8/5k2/8/8/8/8/4pKB1/6N1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on two bishops and a knight" in {
+      val position = "8/5k2/8/8/8/8/4pKN1/6B1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on two knights and a bishop" in {
+      val position = "8/5k2/8/8/8/8/4pKN1/6N1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on three knights (of two colors)" in {
+      val position = "8/5k2/8/8/8/8/4pKN1/6N1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Knight.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on three knights (of two colors)" in {
+      val position = "8/5k2/8/8/8/8/4pKN1/6n1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Knight.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on three knights (of the same color)" in {
+      val position = "8/5k2/8/8/8/8/4pKn1/6n1 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Knight.some
       ))
 
       newGame must beSuccess.like {

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -403,19 +403,19 @@ class AtomicVariantTest extends ChessTest {
     }
 
     "Identify that a player does not have sufficient material to win when they only have a king" in {
-      val position = "8/8/8/8/7p/2k3q1/2K3P1/8 b - - 19 54"
-      val game = fenToGame(position, Atomic)
+      val position = "8/8/8/8/7p/2k3q1/2K3P1/8 b - -"
+      val originalGame = fenToGame(position, Atomic)
 
-      game must beSuccess.like {
+      originalGame must beSuccess.like {
         case game =>
           game.situation.end must beFalse
       }
 
-      val drawGame = game flatMap (_.playMoves(Pos.G3 -> Pos.G2))
+      val newGame = originalGame flatMap (_.playMoves(Pos.G3 -> Pos.G2, Pos.C2 -> Pos.D2))
 
-      drawGame must beSuccess.like {
+      newGame must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.White) must beTrue
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
 
     }
@@ -452,110 +452,6 @@ class AtomicVariantTest extends ChessTest {
       val game = fenToGame(position, Atomic)
       val newGame = game flatMap (_.playMove(
         Pos.E2, Pos.E1, Bishop.some
-      ))
-
-      newGame must beSuccess.like {
-        case game =>
-          game.situation.end must beFalse
-      }
-    }
-
-    "Not draw inappropriately on three bishops (of both square colors)" in {
-      val position = "8/5k2/8/8/8/8/4pKB1/5B2 b - - 1 44"
-      val game = fenToGame(position, Atomic)
-      val newGame = game flatMap (_.playMove(
-        Pos.E2, Pos.E1, Bishop.some
-      ))
-
-      newGame must beSuccess.like {
-        case game =>
-          game.situation.end must beFalse
-      }
-    }
-
-    "Not draw inappropriately on three bishops (of both square colors)" in {
-      val position = "8/5k2/8/8/8/8/4pKB1/6B1 b - - 1 44"
-      val game = fenToGame(position, Atomic)
-      val newGame = game flatMap (_.playMove(
-        Pos.E2, Pos.E1, Bishop.some
-      ))
-
-      newGame must beSuccess.like {
-        case game =>
-          game.situation.end must beFalse
-      }
-    }
-
-    "Not draw inappropriately on two bishops and a knight" in {
-      val position = "8/5k2/8/8/8/8/4pKB1/6N1 b - - 1 44"
-      val game = fenToGame(position, Atomic)
-      val newGame = game flatMap (_.playMove(
-        Pos.E2, Pos.E1, Bishop.some
-      ))
-
-      newGame must beSuccess.like {
-        case game =>
-          game.situation.end must beFalse
-      }
-    }
-
-    "Not draw inappropriately on two bishops and a knight" in {
-      val position = "8/5k2/8/8/8/8/4pKN1/6B1 b - - 1 44"
-      val game = fenToGame(position, Atomic)
-      val newGame = game flatMap (_.playMove(
-        Pos.E2, Pos.E1, Bishop.some
-      ))
-
-      newGame must beSuccess.like {
-        case game =>
-          game.situation.end must beFalse
-      }
-    }
-
-    "Not draw inappropriately on two knights and a bishop" in {
-      val position = "8/5k2/8/8/8/8/4pKN1/6N1 b - - 1 44"
-      val game = fenToGame(position, Atomic)
-      val newGame = game flatMap (_.playMove(
-        Pos.E2, Pos.E1, Bishop.some
-      ))
-
-      newGame must beSuccess.like {
-        case game =>
-          game.situation.end must beFalse
-      }
-    }
-
-    "Not draw inappropriately on three knights (of two colors)" in {
-      val position = "8/5k2/8/8/8/8/4pKN1/6N1 b - - 1 44"
-      val game = fenToGame(position, Atomic)
-      val newGame = game flatMap (_.playMove(
-        Pos.E2, Pos.E1, Knight.some
-      ))
-
-      newGame must beSuccess.like {
-        case game =>
-          game.situation.end must beFalse
-      }
-    }
-
-    "Not draw inappropriately on three knights (of two colors)" in {
-      val position = "8/5k2/8/8/8/8/4pKN1/6n1 b - - 1 44"
-      val game = fenToGame(position, Atomic)
-      val newGame = game flatMap (_.playMove(
-        Pos.E2, Pos.E1, Knight.some
-      ))
-
-      newGame must beSuccess.like {
-        case game =>
-          game.situation.end must beFalse
-      }
-    }
-
-    "Not draw inappropriately on three knights (of the same color)" in {
-      val position = "8/5k2/8/8/8/8/4pKn1/6n1 b - - 1 44"
-      val game = fenToGame(position, Atomic)
-      val newGame = game flatMap (_.playMove(
-        Pos.E2, Pos.E1, Knight.some
       ))
 
       newGame must beSuccess.like {

--- a/src/test/scala/AutodrawTest.scala
+++ b/src/test/scala/AutodrawTest.scala
@@ -116,6 +116,7 @@ K   bB""".autoDraw must_== false
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
           game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+          InsufficientMatingMaterial(game, game.situation.color) must beTrue
       }
     }
     "on knight versus pawn" in {
@@ -129,6 +130,7 @@ K   bB""".autoDraw must_== false
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
           game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+          InsufficientMatingMaterial(game, game.situation.color) must beFalse
       }
     }
     "on bishops versus pawn" in {
@@ -142,6 +144,7 @@ K   bB""".autoDraw must_== false
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
           game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+          InsufficientMatingMaterial(game, game.situation.color) must beFalse
       }
     }
     "on bishops versus queen" in {
@@ -155,6 +158,7 @@ K   bB""".autoDraw must_== false
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
           game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+          InsufficientMatingMaterial(game, game.situation.color) must beFalse
       }
     }
     "on bishops versus queen" in {
@@ -168,6 +172,7 @@ K   bB""".autoDraw must_== false
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
           game.board.variant.insufficientWinningMaterial(game.situation) must beTrue
+          InsufficientMatingMaterial(game, game.situation.color) must beFalse
       }
     }
     "on knight versus pawns" in {
@@ -181,6 +186,7 @@ K   bB""".autoDraw must_== false
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
           game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+          InsufficientMatingMaterial(game, game.situation.color) must beFalse
       }
     }
     "on knight versus pieces" in {
@@ -194,6 +200,7 @@ K   bB""".autoDraw must_== false
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
           game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+          InsufficientMatingMaterial(game, game.situation.color) must beFalse
       }
     }
     "on opposite bishops with queen" in {
@@ -207,6 +214,7 @@ K   bB""".autoDraw must_== false
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
           game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+          InsufficientMatingMaterial(game, game.situation.color) must beFalse
       }
     }
   }

--- a/src/test/scala/AutodrawTest.scala
+++ b/src/test/scala/AutodrawTest.scala
@@ -16,7 +16,7 @@ class AutodrawTest extends ChessTest {
       }
       "opened" in {
         makeGame.playMoves(E2 -> E4, C7 -> C5, C2 -> C3, D7 -> D5, E4 -> D5) map { g =>
-          g.board.autoDraw
+          g.situation.autoDraw
         } must beSuccess(false)
       }
       "two kings" in {
@@ -34,11 +34,6 @@ K      """.autoDraw must_== false
       k
 K     B""".autoDraw must_== true
       }
-      "one knight" in {
-        """
-      k
-K     N""".autoDraw must_== true
-      }
       "one bishop and one knight of different colors" in {
         """
       k
@@ -54,10 +49,10 @@ K N    """.autoDraw must_== false
       k
 K r   B""".autoDraw must_== false
       }
-      "two bishops and one bishop of same colors" in {
+      "one bishop and one bishop of same colors" in {
         """
       k
-K B b B""".autoDraw must_== true
+K   b B""".autoDraw must_== true
       }
       "one bishop and one bishop of different colors" in {
         """
@@ -71,13 +66,13 @@ K   bB""".autoDraw must_== false
       }
       "opened" in {
         makeGame.playMoves(E2 -> E4, C7 -> C5, C2 -> C3, D7 -> D5, E4 -> D5) map { g =>
-          g.board.autoDraw
+          g.situation.autoDraw
         } must beSuccess(false)
       }
       "tons of pointless moves" in {
         val moves = List.fill(30)(List(B1 -> C3, B8 -> C6, C3 -> B1, C6 -> B8))
         makeGame.playMoves(moves.flatten: _*) must beSuccess.like {
-          case g => g.board.autoDraw must_== true
+          case g => g.situation.autoDraw must_== true
         }
       }
     }
@@ -109,16 +104,6 @@ K   bB""".autoDraw must_== false
     }
   }
   "do not detect insufficient material" should {
-    "on two knights" in {
-      val position = "1n2k1n1/8/8/8/8/8/8/4K3 w - - 0 1"
-      fenToGame(position, Standard) must beSuccess.like {
-        case game =>
-          game.situation.autoDraw must beFalse
-          game.situation.end must beFalse
-          game.board.variant.insufficientWinningMaterial(game.board, White) must beTrue
-          game.board.variant.insufficientWinningMaterial(game.board, Black) must beFalse
-      }
-    }
     "on knight versus pawn" in {
       val position = "7K/5k2/7P/6n1/8/8/8/8 b - - 0 40"
       val game = fenToGame(position, Standard)
@@ -131,8 +116,8 @@ K   bB""".autoDraw must_== false
           game.situation.end must beFalse
       }
     }
-    "on bishops versus pawn" in {
-      val position = "1b1b3K/8/5k1P/8/8/8/8/8 b - - 0 40"
+    "on bishop versus pawn" in {
+      val position = "1b5K/8/5k1P/8/8/8/8/8 b - - 0 40"
       val game = fenToGame(position, Standard)
       val newGame = game flatMap (_.playMove(
         Pos.B8, Pos.E5
@@ -141,34 +126,6 @@ K   bB""".autoDraw must_== false
         case game =>
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
-      }
-    }
-    "on bishops versus queen" in {
-      val position = "b2b3K/8/5k1Q/8/8/8/8/8 b - -"
-      val game = fenToGame(position, Standard)
-      val newGame = game flatMap (_.playMove(
-        Pos.F6, Pos.E5
-      ))
-      newGame must beSuccess.like {
-        case game =>
-          game.situation.autoDraw must beFalse
-          game.situation.end must beFalse
-          game.board.variant.insufficientWinningMaterial(game.board, White) must beFalse
-          game.board.variant.insufficientWinningMaterial(game.board, Black) must beFalse
-      }
-    }
-    "on bishops versus queen" in {
-      val position = "1b1b3K/8/5k1Q/8/8/8/8/8 b - -"
-      val game = fenToGame(position, Standard)
-      val newGame = game flatMap (_.playMove(
-        Pos.F6, Pos.E5
-      ))
-      newGame must beSuccess.like {
-        case game =>
-          game.situation.autoDraw must beFalse
-          game.situation.end must beFalse
-          game.board.variant.insufficientWinningMaterial(game.board, White) must beFalse
-          game.board.variant.insufficientWinningMaterial(game.board, Black) must beTrue
       }
     }
     "on knight versus pawns" in {
@@ -188,18 +145,6 @@ K   bB""".autoDraw must_== false
       val game = fenToGame(position, Standard)
       val newGame = game flatMap (_.playMove(
         Pos.E5, Pos.F7
-      ))
-      newGame must beSuccess.like {
-        case game =>
-          game.situation.autoDraw must beFalse
-          game.situation.end must beFalse
-      }
-    }
-    "on opposite bishops with queen" in {
-      val position = "8/8/3Q4/2bK4/B7/8/8/k7 b - - 0 67"
-      val game = fenToGame(position, Standard)
-      val newGame = game flatMap (_.playMove(
-        Pos.A1, Pos.B2
       ))
       newGame must beSuccess.like {
         case game =>

--- a/src/test/scala/CrazyhouseVariantTest.scala
+++ b/src/test/scala/CrazyhouseVariantTest.scala
@@ -20,7 +20,7 @@ class CrazyhouseVariantTest extends ChessTest {
         ))
       }
       game.situation.checkMate must beTrue
-      game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+      game.situation.insufficientWinningMaterial must beFalse
       InsufficientMatingMaterial(game, game.situation.color) must beFalse
     }
 
@@ -38,7 +38,7 @@ class CrazyhouseVariantTest extends ChessTest {
         ))
       }
       game.situation.checkMate must beTrue
-      game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+      game.situation.insufficientWinningMaterial must beFalse
       InsufficientMatingMaterial(game, game.situation.color) must beFalse
     }
 
@@ -47,19 +47,19 @@ class CrazyhouseVariantTest extends ChessTest {
       "tons of pointless moves but shouldn't apply 50-moves" in {
         val moves = List.fill(30)(List(B1 -> C3, B8 -> C6, C3 -> B1, C6 -> B8))
         Game(Crazyhouse).playMoves(moves.flatten: _*) must beSuccess.like {
-          case g => g.board.autoDraw must beFalse
+          case g => g.situation.autoDraw must beFalse
         }
       }
       "from prod should 3fold" in {
         val moves = List(E2 -> E4, E7 -> E6, F2 -> F4, C7 -> C5, E4 -> E5, D7 -> D6, G1 -> F3, B8 -> C6, F1 -> B5, C8 -> D7, B5 -> C6, D7 -> C6, D2 -> D3, C6 -> F3, D1 -> F3, D6 -> D5, E1 -> H1, D8 -> B6, C1 -> E3, B6 -> B2, B1 -> D2, B2 -> B6, A1 -> B1, B6 -> C7, C2 -> C4, A8 -> D8, C4 -> D5, D8 -> D5, D2 -> E4, B7 -> B6, F1 -> D1, G8 -> H6, G2 -> G4, F8 -> E7, G1 -> G2, E8 -> H8, H2 -> H3, F8 -> D8, B1 -> B3, C5 -> C4, B3 -> C3, E7 -> B4, C3 -> C1, D5 -> D3, D1 -> D3, D8 -> D3, C1 -> C2, C4 -> C3, H3 -> H4, C7 -> C6, E4 -> F6, G7 -> F6, F3 -> C6, D3 -> E3, E5 -> F6, H6 -> G4, C6 -> C8, B4 -> F8, C2 -> C3, E3 -> E4, G2 -> F3, G4 -> F6, C8 -> D8, G8 -> G7, D8 -> F6, G7 -> F6, F3 -> E4, F8 -> C5, A2 -> A4, F6 -> G6, A4 -> A5, G6 -> H5, A5 -> B6, A7 -> B6, C3 -> G3, H5 -> H4, G3 -> G7, H7 -> H5, G7 -> F7, H4 -> G3, F7 -> F6, H5 -> H4, F6 -> E6, H4 -> H3, E6 -> G6, G3 -> F2, G6 -> H6, F2 -> G2, H6 -> G6, G2 -> F2, G6 -> H6, F2 -> G2, H6 -> G6, G2 -> F2, G6 -> H6, F2 -> G2, H6 -> G6)
         Game(Crazyhouse).playMoves(moves: _*) must beSuccess.like {
-          case g => g.board.history.threefoldRepetition must beTrue
+          case g => g.situation.threefoldRepetition must beTrue
         }
       }
       "from prod should not 3fold" in {
         val moves = List(E2 -> E4, E7 -> E6, F2 -> F4, C7 -> C5, E4 -> E5, D7 -> D6, G1 -> F3, B8 -> C6, F1 -> B5, C8 -> D7, B5 -> C6, D7 -> C6, D2 -> D3, C6 -> F3, D1 -> F3, D6 -> D5, E1 -> H1, D8 -> B6, C1 -> E3, B6 -> B2, B1 -> D2, B2 -> B6, A1 -> B1, B6 -> C7, C2 -> C4, A8 -> D8, C4 -> D5, D8 -> D5, D2 -> E4, B7 -> B6, F1 -> D1, G8 -> H6, G2 -> G4, F8 -> E7, G1 -> G2, E8 -> H8, H2 -> H3, F8 -> D8, B1 -> B3, C5 -> C4, B3 -> C3, E7 -> B4, C3 -> C1, D5 -> D3, D1 -> D3, D8 -> D3, C1 -> C2, C4 -> C3, H3 -> H4, C7 -> C6, E4 -> F6, G7 -> F6, F3 -> C6, D3 -> E3, E5 -> F6, H6 -> G4, C6 -> C8, B4 -> F8, C2 -> C3, E3 -> E4, G2 -> F3, G4 -> F6, C8 -> D8, G8 -> G7, D8 -> F6, G7 -> F6, F3 -> E4, F8 -> C5, A2 -> A4, F6 -> G6, A4 -> A5, G6 -> H5, A5 -> B6, A7 -> B6, C3 -> G3, H5 -> H4, G3 -> G7, H7 -> H5, G7 -> F7, H4 -> G3, F7 -> F6, H5 -> H4, F6 -> E6, H4 -> H3, E6 -> G6, G3 -> F2, G6 -> H6, F2 -> G2, H6 -> G6, G2 -> F2, G6 -> H6)
         Game(Crazyhouse).playMoves(moves: _*) must beSuccess.like {
-          case g => g.board.history.threefoldRepetition must beFalse
+          case g => g.situation.threefoldRepetition must beFalse
         }
       }
       "not draw when only kings left" in {
@@ -69,7 +69,7 @@ class CrazyhouseVariantTest extends ChessTest {
         }
         game.situation.autoDraw must beFalse
         game.situation.end must beFalse
-        game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+        game.situation.insufficientWinningMaterial must beFalse
         InsufficientMatingMaterial(game, game.situation.color) must beFalse
       }
     }

--- a/src/test/scala/CrazyhouseVariantTest.scala
+++ b/src/test/scala/CrazyhouseVariantTest.scala
@@ -20,6 +20,8 @@ class CrazyhouseVariantTest extends ChessTest {
         ))
       }
       game.situation.checkMate must beTrue
+      game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+      InsufficientMatingMaterial(game, game.situation.color) must beFalse
     }
 
     "pieces to drop, in vain" in {
@@ -36,6 +38,8 @@ class CrazyhouseVariantTest extends ChessTest {
         ))
       }
       game.situation.checkMate must beTrue
+      game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+      InsufficientMatingMaterial(game, game.situation.color) must beFalse
     }
 
     "autodraw" in {
@@ -59,11 +63,14 @@ class CrazyhouseVariantTest extends ChessTest {
         }
       }
       "not draw when only kings left" in {
-        val fenPosition = "k6K/8/8/8/8/8/8/8 w - - 0 25"
+        val fenPosition = "k6K/8/8/8/8/8/8/8/QRRBBNNPPPPPPPPqrrbbnnpppppppp w - - 0 25"
         val game = {
           fenToGame(fenPosition, Crazyhouse).toOption err "error"
         }
-        game.board.autoDraw must beFalse
+        game.situation.autoDraw must beFalse
+        game.situation.end must beFalse
+        game.board.variant.insufficientWinningMaterial(game.situation) must beFalse
+        InsufficientMatingMaterial(game, game.situation.color) must beFalse
       }
     }
     "prod 50 games accumulate hash" in {

--- a/src/test/scala/HordeVariantTest.scala
+++ b/src/test/scala/HordeVariantTest.scala
@@ -12,7 +12,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beFalse
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
       }
     }
 
@@ -22,7 +22,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
     }
 
@@ -32,7 +32,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.black) must beFalse
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
       }
     }
 
@@ -42,7 +42,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
     }
 
@@ -52,7 +52,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.black) must beFalse
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
       }
     }
 
@@ -62,7 +62,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
     }
 
@@ -72,7 +72,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.black) must beFalse
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
       }
     }
 
@@ -82,7 +82,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beFalse
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
       }
     }
 

--- a/src/test/scala/VariantTest.scala
+++ b/src/test/scala/VariantTest.scala
@@ -20,7 +20,7 @@ class VariantTest extends ChessTest {
 
       game should beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
     }
 
@@ -30,7 +30,7 @@ class VariantTest extends ChessTest {
 
       game should beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beFalse
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beFalse
       }
     }
 
@@ -40,7 +40,7 @@ class VariantTest extends ChessTest {
 
       game should beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.board.variant.insufficientWinningMaterial(game.situation) must beTrue
       }
     }
   }


### PR DESCRIPTION
User reported issue https://lichess.org/forum/lichess-feedback/bug-at-atomic

(Code based upon #168) If an atomic player times out in a closed position (no pawn moves available, one or more players may have bishops and/or pawns) and the opponent cannot checkmate, the game is drawn.

Curious edge case: K+B+P versus K+B+P with a blocked a2/h2/a7/h7 pawn and opposite-colored bishops, for example `kbB5/pK6/P7/8/8/8/8/8 w` and `kbB5/pK6/P7/8/8/8/8/8 b`.  Only the player whose bishop attacks the corner square can checkmate.