### PR TITLE
Atomic helpmate with bishop and knight of the same color is possible

### DIFF
--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -83,15 +83,16 @@ case object Atomic extends Variant(
   private def insufficientAtomicWinningMaterial(board: Board) = {
     val kingsAndBishopsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Bishop) }
     lazy val bishopsOnOppositeColors = InsufficientMatingMaterial.bishopsOnOppositeColors(board)
+    lazy val kingsAndKnightsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Knight) }
     lazy val kingsRooksAndMinorsOnly = board.pieces forall { p => (p._2 is King) || (p._2 is Rook) || (p._2 is Bishop) || (p._2 is Knight) }
-    lazy val rookExists = board.pieces exists { _._2 is Rook }
 
     // Bishops of opposite color (no other pieces) endgames are dead drawn
     // except if either player has multiple bishops so a helpmate is possible
     if (board.count(White) >= 2 && board.count(Black) >= 2) kingsAndBishopsOnly && board.pieces.size <= 4 && bishopsOnOppositeColors
 
-    // Queen, rook + any, bishop pair, or any 3 minor pieces can mate
-    else kingsRooksAndMinorsOnly && !bishopsOnOppositeColors && board.pieces.size <= (if (rookExists) 3 else 4)
+    // Queen, rook + any, bishop + any (same piece color), or 3 knights can mate
+    else if (kingsAndKnightsOnly) board.pieces.size <= 4
+    else kingsRooksAndMinorsOnly && !bishopsOnOppositeColors && board.pieces.size <= 3
   }
 
   /*

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -447,11 +447,24 @@ class AtomicVariantTest extends ChessTest {
       }
     }
 
-    "Not draw inappropriately on three bishops (of both square colors)" in {
-      val position = "8/5k2/8/8/8/8/4pKb1/5b2 b - - 1 44"
+    "Not draw inappropriately on two bishops (of both square colors)" in {
+      val position = "8/5k2/8/8/8/8/4pK2/5b2 b - - 1 44"
       val game = fenToGame(position, Atomic)
       val newGame = game flatMap (_.playMove(
         Pos.E2, Pos.E1, Bishop.some
+      ))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately on bishop and knight" in {
+      val position = "8/5k2/8/8/8/8/4pK2/5b2 b - - 1 44"
+      val game = fenToGame(position, Atomic)
+      val newGame = game flatMap (_.playMove(
+        Pos.E2, Pos.E1, Knight.some
       ))
 
       newGame must beSuccess.like {


### PR DESCRIPTION
Atomic helpmates by series of legal moves for K versus K+B+(B or N) of the same color are possible.