### PR TITLE
Adds ultrabullet to speed.limited

### DIFF
--- a/src/main/scala/Speed.scala
+++ b/src/main/scala/Speed.scala
@@ -21,7 +21,7 @@ object Speed {
   case object Correspondence extends Speed(4, "correspondence", 21600 to Int.MaxValue, "Correspondence", "Correspondence games")
 
   val all = List(UltraBullet, Bullet, Blitz, Rapid, Classical, Correspondence)
-  val limited = List(Bullet, Blitz, Rapid, Classical)
+  val limited = List(UltraBullet, Bullet, Blitz, Rapid, Classical)
 
   val byId = all map { v => (v.id, v) } toMap
 


### PR DESCRIPTION
This pull request adds UltraBullet to speed.limited, which means that it will show up in the lobby as a filter-able speed control. Currently, all ultrabullet games will show up only when you have the bullet option enabled but instead there should be a separate option for ultrabullet. Ultrabullet is the only real-time game speed that you can not filter, and thus it should be added.