### PR TITLE
Remove Antichess from divisionSensibleVariants

### DIFF
--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -206,7 +206,6 @@ object Variant {
     chess.variant.Chess960,
     chess.variant.ThreeCheck,
     chess.variant.KingOfTheHill,
-    chess.variant.Antichess,
     chess.variant.FromPosition
   )
 


### PR DESCRIPTION
It's not useful to divide an antichess game in phases by the same logic as a Standard game, and there's not even consensus on what an antichess "midgame" would consist of.