### PR TITLE
auto draw on fivefold repetition

### DIFF
--- a/src/main/scala/Board.scala
+++ b/src/main/scala/Board.scala
@@ -163,7 +163,7 @@ case class Board(
   def count(p: Piece): Int = pieces.values count (_ == p)
   def count(c: Color): Int = pieces.values count (_.color == c)
 
-  def autoDraw: Boolean = history.fiftyMoves || variant.insufficientWinningMaterial(this)
+  def autoDraw: Boolean = history.fiftyMoves || variant.insufficientWinningMaterial(this) || history.fivefoldRepetition
 
   def situationOf(color: Color) = Situation(this, color)
 

--- a/src/main/scala/History.scala
+++ b/src/main/scala/History.scala
@@ -41,18 +41,22 @@ case class History(
   def setHalfMoveClock(v: Int) =
     copy(positionHashes = History.spoofHashes(v + 1))
 
-  def threefoldRepetition: Boolean = halfMoveClock >= 8 && {
+  private def isRepetition(times: Int) = halfMoveClock >= (times - 1) * 4 && {
     // compare only hashes for positions with the same side to move
-    val positions = (positionHashes grouped Hash.size).sliding(1, 2).flatten.toList
+    val positions = positionHashes.sliding(Hash.size, 2 * Hash.size).toList
     positions.headOption match {
       case Some(Array(x, y, z)) =>
         (positions count {
           case Array(x2, y2, z2) => x == x2 && y == y2 && z == z2
           case _                 => false
-        }) >= 3
-      case _ => false
+        }) >= times
+      case _ => times <= 1
     }
   }
+
+  def threefoldRepetition = isRepetition(3)
+
+  def fivefoldRepetition = isRepetition(5)
 
   def fiftyMoves: Boolean = halfMoveClock >= 100
 

--- a/src/test/scala/AutodrawTest.scala
+++ b/src/test/scala/AutodrawTest.scala
@@ -299,6 +299,103 @@ K   bB""".autoDraw must_== false
         }
       }
     }
+    "by fivefold" in {
+      // https://lichess.org/BdvgPSMd#82
+      val moves = List(
+        E2 -> E4,
+        C7 -> C5,
+        G1 -> F3,
+        D7 -> D6,
+        D2 -> D4,
+        C5 -> D4,
+        F3 -> D4,
+        G8 -> F6,
+        B1 -> C3,
+        G7 -> G6,
+        C1 -> G5,
+        F8 -> G7,
+        F2 -> F4,
+        B8 -> C6,
+        F1 -> B5,
+        C8 -> D7,
+        D4 -> C6,
+        D7 -> C6,
+        B5 -> C6,
+        B7 -> C6,
+        E1 -> G1,
+        D8 -> B6,
+        G1 -> H1,
+        B6 -> B2,
+        D1 -> D3,
+        E8 -> G8,
+        A1 -> B1,
+        B2 -> A3,
+        B1 -> B3,
+        A3 -> C5,
+        C3 -> A4,
+        C5 -> A5,
+        A4 -> C3,
+        A8 -> B8,
+        F4 -> F5,
+        B8 -> B3,
+        A2 -> B3,
+        F6 -> G4,
+        C3 -> E2,
+        A5 -> C5,
+        H2 -> H3,
+        G4 -> F2,
+        F1 -> F2,
+        C5 -> F2,
+        F5 -> G6,
+        H7 -> G6,
+        G5 -> E7,
+        F8 -> E8,
+        E7 -> D6,
+        F2 -> F1,
+        H1 -> H2,
+        G7 -> E5,
+        D6 -> E5,
+        E8 -> E5,
+        D3 -> D8,
+        G8 -> G7,
+        D8 -> D4,
+        F7 -> F6,
+        E2 -> G3,
+        F1 -> F4,
+        D4 -> D7,
+        G7 -> H6,
+        D7 -> F7,
+        E5 -> G5,
+        F7 -> F8,
+        H6 -> H7,
+        F8 -> F7,
+        H7 -> H8,
+        F7 -> F8,
+        H8 -> H7,
+        F8 -> F7,
+        H7 -> H6,
+        F7 -> F8,
+        H6 -> H7,
+        F8 -> F7,
+        H7 -> H8,
+        F7 -> F8,
+        H8 -> H7,
+        F8 -> F7,
+        H7 -> H6,
+        F7 -> F8,
+        H6 -> H7
+      )
+      "from prod should be fivefold" in {
+        makeGame.playMoves(moves: _*) must beSuccess.like {
+          case g => g.situation.autoDraw must beTrue
+        }
+      }
+      "from prod should not be fivefold" in {
+        makeGame.playMoves(moves.dropRight(1): _*) must beSuccess.like {
+          case g => g.situation.autoDraw must beFalse
+        }
+      }
+    }
   }
   "do not detect insufficient material" should {
     "on two knights" in {

--- a/src/test/scala/CrazyhouseVariantTest.scala
+++ b/src/test/scala/CrazyhouseVariantTest.scala
@@ -47,7 +47,9 @@ class CrazyhouseVariantTest extends ChessTest {
       "tons of pointless moves but shouldn't apply 50-moves" in {
         val moves = List.fill(30)(List(B1 -> C3, B8 -> C6, C3 -> B1, C6 -> B8))
         Game(Crazyhouse).playMoves(moves.flatten: _*) must beSuccess.like {
-          case g => g.board.autoDraw must beFalse
+          case g =>
+            g.board.history.fiftyMoves must beFalse
+            g.board.autoDraw must beTrue // fivefold repetition
         }
       }
       "from prod should 3fold" in {


### PR DESCRIPTION
Implementing a FIDE rule from 2018:
> 9.6 If one or both of the following occur(s) then the game is drawn:
> 9.6.1 the same position has appeared, as in 9.2.2 at least five times.

Unlike threefold repetition, fivefold does not need to be claimed.

Recent example: https://lichess.org/forum/lichess-feedback/perpetual-check-still-i-lost-the-game