### PR TITLE
apply mating material check by situation (closes #168)

### DIFF
--- a/src/main/scala/Board.scala
+++ b/src/main/scala/Board.scala
@@ -163,7 +163,7 @@ case class Board(
   def count(p: Piece): Int = pieces.values count (_ == p)
   def count(c: Color): Int = pieces.values count (_.color == c)
 
-  def autoDraw: Boolean = history.fiftyMoves || variant.insufficientWinningMaterial(this) || history.fivefoldRepetition
+  def autoDraw: Boolean = history.fiftyMoves || variant.isInsufficientMaterial(this) || history.fivefoldRepetition
 
   def situationOf(color: Color) = Situation(this, color)
 

--- a/src/main/scala/Situation.scala
+++ b/src/main/scala/Situation.scala
@@ -31,6 +31,8 @@ case class Situation(board: Board, color: Color) {
 
   def autoDraw: Boolean = board.autoDraw || board.variant.specialDraw(this)
 
+  def opponentHasInsufficientMaterial: Boolean = board.variant.opponentHasInsufficientMaterial(this)
+
   lazy val threefoldRepetition: Boolean = board.history.threefoldRepetition
 
   def variantEnd = board.variant specialEnd this

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -41,14 +41,14 @@ case object Antichess
     situation.board.piecesOf(situation.color).isEmpty || situation.moves.isEmpty
   }
 
-  // In antichess, there is no checkmate condition therefore a player may only draw either by agreement
-  // , blockade or stalemate - a player always has sufficient material to win otherwise
-  override def insufficientWinningMaterial(board: Board, color: Color) = false
+  // In antichess, there is no checkmate condition therefore a player may only draw either by agreement,
+  // blockade or stalemate. A player always has sufficient material to win otherwise.
+  override def opponentHasInsufficientMaterial(situation: Situation) = false
 
   // No player can win if the only remaining pieces are opposing bishops on different coloured
   // diagonals. There may be pawns that are incapable of moving and do not attack the right color
   // of square to allow the player to force their opponent to capture their bishop, also resulting in a draw
-  override def insufficientWinningMaterial(board: Board) = {
+  override def isInsufficientMaterial(board: Board) = {
     // Exit early if we are not in a situation with only bishops and pawns
     val bishopsAndPawns = board.pieces.values.forall(p => p.is(Bishop) || p.is(Pawn)) &&
       board.pieces.values.exists(_.is(Bishop))

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -118,7 +118,7 @@ case object Atomic
    * mate would be not be very likely. Additionally, a player can only mate another player with sufficient material.
    * We also look out for closed positions (pawns that cannot move and kings which cannot capture them.)
    */
-  override def insufficientWinningMaterial(board: Board) = {
+  override def isInsufficientMaterial(board: Board) = {
     insufficientAtomicWinningMaterial(board) || atomicClosedPosition(board)
   }
 
@@ -137,8 +137,8 @@ case object Atomic
     * a piece in the opponent's king's proximity. On the other hand, a king alone or a king with
     * immobile pawns is not sufficient material to win with.
     */
-  override def insufficientWinningMaterial(board: Board, color: Color) =
-    board.rolesOf(color) == List(King)
+  override def opponentHasInsufficientMaterial(situation: Situation) =
+    situation.board.rolesOf(!situation.color) == List(King)
 
   /** Atomic chess has a special end where a king has been killed by exploding with an adjacent captured piece */
   override def specialEnd(situation: Situation) = situation.board.kingPos.size != 2

--- a/src/main/scala/variant/Crazyhouse.scala
+++ b/src/main/scala/variant/Crazyhouse.scala
@@ -84,8 +84,8 @@ case object Crazyhouse
     super.checkmate(situation) && !canDropStuff(situation)
 
   // there is always sufficient mating material in Crazyhouse
-  override def insufficientWinningMaterial(board: Board, color: Color) = false
-  override def insufficientWinningMaterial(board: Board)               = false
+  override def opponentHasInsufficientMaterial(situation: Situation) = false
+  override def isInsufficientMaterial(board: Board)                  = false
 
   def possibleDrops(situation: Situation): Option[List[Pos]] =
     if (!situation.check) None

--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -66,7 +66,7 @@ case object Horde
     * In horde chess, black can win unless a fortress stalemate is unavoidable.
     *  Auto-drawing the game should almost never happen, but it did in https://lichess.org/xQ2RsU8N#121
     */
-  override def insufficientWinningMaterial(board: Board) = hordeClosedPosition(board)
+  override def isInsufficientMaterial(board: Board) = hordeClosedPosition(board)
 
   /**
     * In horde chess, the horde cannot win on * V K or [BN]{2} v K or just one piece
@@ -74,9 +74,11 @@ case object Horde
     * Technically there are some positions where stalemate is unavoidable which
     * this method does not detect; however, such are trivial to premove.
     */
-  override def insufficientWinningMaterial(board: Board, color: Color): Boolean = {
+  override def opponentHasInsufficientMaterial(situation: Situation): Boolean = {
+    val board         = situation.board
+    val opponentColor = !situation.color
     lazy val fortress = hordeClosedPosition(board) // costly function call
-    if (color == Color.white) {
+    if (opponentColor == Color.white) {
       lazy val notKingPieces           = InsufficientMatingMaterial.nonKingPieces(board) toList
       val horde                        = board.piecesOf(Color.white)
       lazy val hordeBishopSquareColors = horde.filter(_._2.is(Bishop)).toList.map(_._1.color).distinct

--- a/src/main/scala/variant/KingOfTheHill.scala
+++ b/src/main/scala/variant/KingOfTheHill.scala
@@ -21,7 +21,6 @@ case object KingOfTheHill
   /**
     * You only need a king to be able to win in this variant
     */
-  override def insufficientWinningMaterial(board: Board, color: Color) = false
-
-  override def insufficientWinningMaterial(board: Board) = false
+  override def opponentHasInsufficientMaterial(situation: Situation) = false
+  override def isInsufficientMaterial(board: Board)                  = false
 }

--- a/src/main/scala/variant/RacingKings.scala
+++ b/src/main/scala/variant/RacingKings.scala
@@ -39,8 +39,8 @@ case object RacingKings
 
   override val initialFen = "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1"
 
-  override def insufficientWinningMaterial(board: Board)               = false
-  override def insufficientWinningMaterial(board: Board, color: Color) = false
+  override def isInsufficientMaterial(board: Board)                  = false
+  override def opponentHasInsufficientMaterial(situation: Situation) = false
 
   private def reachedGoal(board: Board, color: Color) =
     board.kingPosOf(color) exists (_.y == 8)

--- a/src/main/scala/variant/ThreeCheck.scala
+++ b/src/main/scala/variant/ThreeCheck.scala
@@ -28,10 +28,10 @@ case object ThreeCheck
   /**
     * It's not possible to check or checkmate the opponent with only a king
     */
-  override def insufficientWinningMaterial(board: Board, color: Color) =
-    board.rolesOf(color) == List(King)
+  override def opponentHasInsufficientMaterial(situation: Situation) =
+    situation.board.rolesOf(!situation.color) == List(King)
 
   // When there is insufficient mating material, there is still potential to win by checking the opponent 3 times
   // by the variant ending. However, no players can check if there are only kings remaining
-  override def insufficientWinningMaterial(board: Board) = board.pieces.values.forall(_ is King)
+  override def isInsufficientMaterial(board: Board) = board.pieces.values.forall(_ is King)
 }

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -112,16 +112,17 @@ abstract class Variant private[variant] (
   @silent def specialDraw(situation: Situation) = false
 
   /**
-    * Returns true if neither player can win
+    * Returns true if neither player can win. The game should end immediately.
     */
-  def insufficientWinningMaterial(board: Board) = InsufficientMatingMaterial(board)
+  def isInsufficientMaterial(board: Board) = InsufficientMatingMaterial(board)
 
   /**
-    * Returns true if the player of the given colour has insufficient material to win.
-    * This can be used to determine whether a player losing on time against a player
-    * who doesn't have enough material to win should draw instead.
+    * Returns true if the other player cannot win. This is relevant when the
+    * side to move times out or disconnects. Instead of losing on time,
+    * the game should be drawn.
     */
-  def insufficientWinningMaterial(board: Board, color: Color) = InsufficientMatingMaterial(board, color)
+  def opponentHasInsufficientMaterial(situation: Situation) =
+    InsufficientMatingMaterial(situation.board, !situation.color)
 
   // Some variants have an extra effect on the board on a move. For example, in Atomic, some
   // pieces surrounding a capture explode

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -405,7 +405,7 @@ class AtomicVariantTest extends ChessTest {
     }
 
     "Identify that a player does not have sufficient material to win when they only have a king" in {
-      val position = "8/8/8/8/7p/2k3q1/2K3P1/8 b - - 19 54"
+      val position = "8/8/8/8/7p/2k4q/2K3P1/8 w - - 19 54"
       val game     = fenToGame(position, Atomic)
 
       game must beSuccess.like {
@@ -413,12 +413,11 @@ class AtomicVariantTest extends ChessTest {
           game.situation.end must beFalse
       }
 
-      val drawGame = game flatMap (_.playMoves(Pos.G3 -> Pos.G2))
+      val drawGame = game flatMap (_.playMoves(Pos.G2 -> Pos.H3))
 
       drawGame must beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.White) must beTrue
+          game.situation.opponentHasInsufficientMaterial must beTrue
       }
 
     }

--- a/src/test/scala/AutodrawTest.scala
+++ b/src/test/scala/AutodrawTest.scala
@@ -404,8 +404,7 @@ K   bB""".autoDraw must_== false
         case game =>
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
-          game.board.variant.insufficientWinningMaterial(game.board, White) must beTrue
-          game.board.variant.insufficientWinningMaterial(game.board, Black) must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
     "on knight versus pawn" in {
@@ -419,6 +418,7 @@ K   bB""".autoDraw must_== false
         case game =>
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
     "on bishops versus pawn" in {
@@ -432,6 +432,7 @@ K   bB""".autoDraw must_== false
         case game =>
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
     "on bishops versus queen" in {
@@ -445,8 +446,7 @@ K   bB""".autoDraw must_== false
         case game =>
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
-          game.board.variant.insufficientWinningMaterial(game.board, White) must beFalse
-          game.board.variant.insufficientWinningMaterial(game.board, Black) must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
     "on bishops versus queen" in {
@@ -460,8 +460,7 @@ K   bB""".autoDraw must_== false
         case game =>
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
-          game.board.variant.insufficientWinningMaterial(game.board, White) must beFalse
-          game.board.variant.insufficientWinningMaterial(game.board, Black) must beTrue
+          game.situation.opponentHasInsufficientMaterial must beTrue
       }
     }
     "on knight versus pawns" in {
@@ -475,6 +474,7 @@ K   bB""".autoDraw must_== false
         case game =>
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
     "on knight versus pieces" in {
@@ -488,6 +488,7 @@ K   bB""".autoDraw must_== false
         case game =>
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
     "on opposite bishops with queen" in {
@@ -501,6 +502,7 @@ K   bB""".autoDraw must_== false
         case game =>
           game.situation.autoDraw must beFalse
           game.situation.end must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
   }

--- a/src/test/scala/CrazyhouseVariantTest.scala
+++ b/src/test/scala/CrazyhouseVariantTest.scala
@@ -22,6 +22,7 @@ class CrazyhouseVariantTest extends ChessTest {
         )
       }
       game.situation.checkMate must beTrue
+      game.situation.opponentHasInsufficientMaterial must beFalse
     }
 
     "pieces to drop, in vain" in {
@@ -40,6 +41,7 @@ class CrazyhouseVariantTest extends ChessTest {
         )
       }
       game.situation.checkMate must beTrue
+      game.situation.opponentHasInsufficientMaterial must beFalse
     }
 
     "autodraw" in {
@@ -259,7 +261,9 @@ class CrazyhouseVariantTest extends ChessTest {
         val game = {
           fenToGame(fenPosition, Crazyhouse).toOption err "error"
         }
-        game.board.autoDraw must beFalse
+        game.situation.autoDraw must beFalse
+        game.situation.end must beFalse
+        game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
     "prod 50 games accumulate hash" in {

--- a/src/test/scala/HordeVariantTest.scala
+++ b/src/test/scala/HordeVariantTest.scala
@@ -12,8 +12,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.white) must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
 
@@ -23,8 +22,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.opponentHasInsufficientMaterial must beTrue
       }
     }
 
@@ -34,8 +32,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.black) must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
 
@@ -45,8 +42,9 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.autoDraw must beFalse
+          game.situation.end must beFalse
+          game.situation.opponentHasInsufficientMaterial must beTrue
       }
     }
 
@@ -56,8 +54,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.opponentHasInsufficientMaterial must beTrue
       }
     }
 
@@ -67,8 +64,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.black) must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
 
@@ -78,8 +74,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.opponentHasInsufficientMaterial must beTrue
       }
     }
 
@@ -89,8 +84,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.black) must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
 
@@ -100,8 +94,7 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.white) must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
 
@@ -111,7 +104,8 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board) must beTrue
+          game.situation.autoDraw must beTrue
+          game.situation.opponentHasInsufficientMaterial must beTrue
       }
     }
 
@@ -121,7 +115,8 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board) must beTrue
+          game.situation.autoDraw must beTrue
+          game.situation.opponentHasInsufficientMaterial must beTrue
       }
     }
 
@@ -131,7 +126,8 @@ class HordeVariantTest extends ChessTest {
 
       game must beSuccess.like {
         case game =>
-          game.situation.board.variant.insufficientWinningMaterial(game.situation.board) must beFalse
+          game.situation.autoDraw must beFalse
+          game.situation.opponentHasInsufficientMaterial must beTrue
       }
     }
   }

--- a/src/test/scala/VariantTest.scala
+++ b/src/test/scala/VariantTest.scala
@@ -53,8 +53,7 @@ class VariantTest extends ChessTest {
 
       game should beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.opponentHasInsufficientMaterial must beTrue
       }
     }
 
@@ -64,8 +63,7 @@ class VariantTest extends ChessTest {
 
       game should beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.white) must beFalse
+          game.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
 
@@ -75,8 +73,7 @@ class VariantTest extends ChessTest {
 
       game should beSuccess.like {
         case game =>
-          game.situation.board.variant
-            .insufficientWinningMaterial(game.situation.board, Color.white) must beTrue
+          game.situation.opponentHasInsufficientMaterial must beTrue
       }
     }
   }


### PR DESCRIPTION
Same as #168, minus other refactorings, so hopefully easier to review. Clearly distinguishes:
* `isInsufficientMaterial`: Neither side can win. The game should end immediately.
* `opponentHasInsufficientMaterial`: Relevant when the side to move times out or disconnects.

Thanks @ddugovic for the original PR.