### PR TITLE
Group Icelandic-Palme with existing B01 openings

### DIFF
--- a/src/main/scala/StartingPosition.scala
+++ b/src/main/scala/StartingPosition.scala
@@ -43,13 +43,6 @@ object StartingPosition {
           false
         ),
         StartingPosition(
-          "B01",
-          "Scandinavian Defense, Icelandic-Palme Gambit",
-          "rnbqkb1r/ppp2ppp/4pn2/3P4/2P5/8/PP1P1PPP/RNBQKBNR w KQkq - 0 4",
-          "Scandinavian_Defense",
-          "1. e4 d5 2. exd5 Nf6 3. c4 e6"
-        ),
-        StartingPosition(
           "B02",
           "Alekhine's Defence",
           "rnbqkb1r/pppppppp/5n2/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 2 2",
@@ -433,6 +426,13 @@ object StartingPosition {
           "rnbqkb1r/ppp1pppp/5n2/3P4/3P4/8/PPP2PPP/RNBQKBNR b KQkq - 0 3",
           "Scandinavian_Defense#2...Nf6",
           "1. e4 d5 2. exd5 Nf6 3. d4"
+        ),
+        StartingPosition(
+          "B01",
+          "Scandinavian Defence: Icelandic-Palme Gambit",
+          "rnbqkb1r/ppp2ppp/4pn2/3P4/2P5/8/PP1P1PPP/RNBQKBNR w KQkq - 0 4",
+          "Scandinavian_Defense#2...Nf6",
+          "1. e4 d5 2. exd5 Nf6 3. c4 e6"
         ),
         StartingPosition(
           "C44",


### PR DESCRIPTION
Tidy up commit

I didn't notice that two other B01 openings were present when I added Icelandic-Palme variation in #191 
This commit updates the newly added Icelandic-Palme entry to look more like the two existing entries.

- Move Icelandic-Palme Gambit next to the other two B01 openings
- Update display name to match the other two B01 openings,
  Old "Scandinavian Defense, Icelandic-Palme Gambit"
  New "Scandinavian Defence: Icelandic-Palme Gambit"
- Update Wiki-link to Icelandic-Palme specific section (same section
  as Modern)