### PR TITLE
Adjudicating Atomic positions with closed pawn structure and a pawnitized bishop as a draw

### DIFF
--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -131,11 +131,12 @@ case object Atomic
         && InsufficientMatingMaterial.pawnBlockedByPawn(actor, board))
         || actor.piece.is(King) || actor.piece.is(Bishop)
     )
-    val bishopColoring =
-      for ((pos, piece) <- board.pieces if piece.is(Bishop))
-        yield (piece.color, pos.color)
-    closedStructure && (bishopColoring.size == 0 ||
-    bishopPawnitized(board, bishopColoring.head._1, bishopColoring.head._2))
+    val randomBishop = board.pieces.find { case (_, piece) => piece.is(Bishop) }
+    val bishopsAbsentOrPawnitized = randomBishop match {
+      case Some((pos, piece)) => bishopPawnitized(board, piece.color, pos.color)
+      case None               => true
+    }
+    closedStructure && bishopsAbsentOrPawnitized
   }
 
   private def bishopPawnitized(board: Board, sideWithBishop: Color, bishopSquares: Color) = {

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -126,9 +126,24 @@ case object Atomic
     * Since a king cannot capture, K + P vs K + P where none of the pawns can move is an automatic draw
     */
   private def atomicClosedPosition(board: Board) = {
-    board.actors.values.forall(actor =>
+    val closedStructure = board.actors.values.forall(actor =>
       (actor.piece.is(Pawn) && actor.moves.isEmpty
-        && InsufficientMatingMaterial.pawnBlockedByPawn(actor, board)) || actor.piece.is(King)
+        && InsufficientMatingMaterial.pawnBlockedByPawn(actor, board))
+        || actor.piece.is(King) || actor.piece.is(Bishop)
+    )
+    val bishopColoring =
+      for ((pos, piece) <- board.pieces if piece.is(Bishop))
+        yield (piece.color, pos.color)
+    closedStructure && (bishopColoring.size == 0 ||
+    bishopPawnitized(board, bishopColoring.head._1, bishopColoring.head._2))
+  }
+
+  private def bishopPawnitized(board: Board, sideWithBishop: Color, bishopSquares: Color) = {
+    board.actors.values.forall(actor =>
+      (actor.piece.is(Pawn) && actor.piece.is(sideWithBishop)) ||
+        (actor.piece.is(Pawn) && actor.piece.is(!sideWithBishop) && actor.pos.color == !bishopSquares) ||
+        (actor.piece.is(Bishop) && actor.piece.is(sideWithBishop) && actor.pos.color == bishopSquares) ||
+        actor.piece.is(King)
     )
   }
 

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -626,5 +626,41 @@ class AtomicVariantTest extends ChessTest {
       val errorGame = game flatMap (_.playMove(Pos.E1, Pos.B1))
       errorGame must beFailure
     }
+
+    "An automatic draw in a closed position with kings, pawns and a pawnitized bishop" in {
+      val position = "8/8/2k1p3/5p2/4PP2/1b6/4K3/8 w - - 0 1"
+      val game     = fenToGame(position, Atomic)
+      val newGame  = game flatMap (_.playMove(Pos.E4, Pos.E5))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.autoDraw must beTrue
+          game.situation.end must beTrue
+      }
+    }
+
+    "Not draw inappropriately on blocked pawns with a non-pawnitized bishop" in {
+      val position = "8/8/2k5/5p2/8/2b2P2/8/3K4 w - - 0 1"
+      val game     = fenToGame(position, Atomic)
+      val newGame  = game flatMap (_.playMove(Pos.F3, Pos.F4))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.autoDraw must beFalse
+          game.situation.end must beFalse
+      }
+    }
+
+    "Not draw inappropriately if both sides have a pawnitized bishop" in {
+      val position = "6bk/4B2p/8/7P/4K3/8/8/8 w - - 0 1"
+      val game     = fenToGame(position, Atomic)
+      val newGame  = game flatMap (_.playMove(Pos.H5, Pos.H6))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.autoDraw must beFalse
+          game.situation.end must beFalse
+      }
+    }
   }
 }

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -662,5 +662,17 @@ class AtomicVariantTest extends ChessTest {
           game.situation.end must beFalse
       }
     }
+
+    "Checkmate overrides closed position" in {
+      val position = "8/8/b1p5/kpP5/p3K3/PP6/8/8 w - - 0 1"
+      val game     = fenToGame(position, Atomic)
+      val newGame  = game flatMap (_.playMove(Pos.B3, Pos.B4))
+
+      newGame must beSuccess.like {
+        case game =>
+          game.situation.autoDraw must beFalse
+          game.situation.end must beTrue
+      }
+    }
   }
 }


### PR DESCRIPTION
Examples of positions in Atomic which are draws according to the FIDE rule of no legal move sequence to mate, but are not adjudicated as such by lichess: https://lichess.org/5HqshWY6#168 https://lichess.org/X4p7XV0s#91 https://lichess.org/VR3El4CK#80 These are not very rare, as leaving the extra opponent's bishop unable to capture your pawns is a recurring drawing idea in Atomic (see https://lichess.org/study/WOWizkm4). This is very annoying when happens, as everyone understands this is a dead draw where even stupid moves cannot lead to a win of either side.

This patch fixes these positions by using the following criteria (all must hold): 1) the sides have only kings, bishops and pawns 2) pawn structure is completely blocked - each pawn has no legal moves and is blocked by an opponent's pawn; this also assumes that pawns are not giving a check 3) bishops, if present, must be all of the same owner (white or black), all of the same square color (light or dark) and all the opponent's pawns (if any) are on opposite color squares.

All such positions are dead drawn for the following reasons. Kings cannot capture anything by Atomic rules. Pawns cannot move now and won't be able to as the bishops cannot be put under attack of enemy pawns as they are of the wrong square color. Bishops can move freely but cannot capture anything since they are of the wrong square color. Thus no zeroing moves are possible from such positions. The only remaining possibility is checkmate by a pawn or a bishop.

Suppose that the king of the side without bishops - without loss of generality, white - is in Atomic checkmate by a pawn or a bishop, then it is on the same square color - without loss of generality, dark - as all the pawns and bishops of the opponent. Let us consider why the horizontal and vertical retreats - to the light squares - are not available for the white king, which is in checkmate. They cannot be occupied by the black king, since this would mean that white is not even in check, let alone checkmate. They also cannot be occupied or attacked by opponent's pawns or bishops, since they all stand on dark squares. The only remaining possibility is that they are all occupied by white pawns. This is a contradiction since for the king on the 1st row this will require a white pawn on the 1st row, and in other cases the pawn below the king is blocked by the own king rather than enemy pawn, contradicting our conditions of detecting dead draws.

The king of the side with bishops can only be possibly checked by a pawn. Such a check was not given in the adjudicated position by our conditions. Since the pawns don't move, it can only be given later if the kings are connected, our king steps under a pawn attack using the immunity, and the opponent's king disconnects. This cannot, however, be a checkmate, since our king can always use the square where the opponent's king just was.