### PR TITLE
Add Bird's opening to the tournament starting position list

### DIFF
--- a/src/main/scala/StartingPosition.scala
+++ b/src/main/scala/StartingPosition.scala
@@ -1030,6 +1030,25 @@ object StartingPosition {
       )
     ),
     Category(
+      "f4",
+      List(
+        StartingPosition(
+          "A02",
+          "Bird's Opening",
+          "rnbqkbnr/pppppppp/8/8/5P2/8/PPPPP1PP/RNBQKBNR b KQkq - 0 1",
+          "Bird's_Opening",
+          "1. f4"
+        ),
+        StartingPosition(
+          "A02",
+          "Bird's Opening: Dutch Variation",
+          "rnbqkbnr/ppp1pppp/8/3p4/5P2/8/PPPPP1PP/RNBQKBNR w KQkq - 0 2",
+          "Bird's_Opening",
+          "1. f4 d5"
+        )
+      )
+    ),
+    Category(
       "g3",
       List(
         StartingPosition(


### PR DESCRIPTION
This PR adds the Bird's Opening (1. f4) and Bird's Opening: Dutch Variation (1. f4 d5) to the list of available starting positions for tournaments. 

Ran into the unavailalbility during Chessweeb's stream where he tried to set up a Bird's Opening tournament.