### PR TITLE
fix: threefold on initial position

### DIFF
--- a/src/main/scala/Drop.scala
+++ b/src/main/scala/Drop.scala
@@ -31,8 +31,10 @@ case class Drop(
       none
     )
 
-    board updateHistory {
-      _.copy(positionHashes = Hash(Situation(board, !piece.color)) ++ board.history.positionHashes)
+    board updateHistory { h =>
+      val basePositionHashes =
+        if (h.positionHashes.isEmpty) Hash(situationBefore) else board.history.positionHashes
+      h.copy(positionHashes = Hash(Situation(board, !piece.color)) ++ basePositionHashes)
     }
   }
 

--- a/src/test/scala/AutodrawTest.scala
+++ b/src/test/scala/AutodrawTest.scala
@@ -283,12 +283,12 @@ K   bB""".autoDraw must_== false
           case g => g.board.history.threefoldRepetition must beFalse
         }
       }
-      // "3fold on initial position - broken" in {
-      //   val moves = List.fill(2)(List(G1 -> F3, B8 -> C6, F3 -> G1, C6 -> B8)).flatten
-      //   makeGame.playMoves(moves: _*) must beValid.like {
-      //     case g => g.board.history.threefoldRepetition must beTrue
-      //   }
-      // }
+      "3fold on initial position" in {
+        val moves = List.fill(2)(List(G1 -> F3, B8 -> C6, F3 -> G1, C6 -> B8)).flatten
+        makeGame.playMoves(moves: _*) must beValid.like {
+          case g => g.board.history.threefoldRepetition must beTrue
+        }
+      }
       "pawn move then minimalist 3fold" in {
         val moves = List(E2 -> E4, E7 -> E5) ::: List
           .fill(2)(List(G1 -> F3, B8 -> C6, F3 -> G1, C6 -> B8))


### PR DESCRIPTION
Fixes #203 

This PR uncomment a test that defines the issue and fixes it by adding one extra positionHash when it is the first move, namely, the hash of the current `Situation` (before the move, or, the initial position).

This was the chosen solution because the `positionHashes` is, in fact, a `Situation` hash. As a `Situation` depend on a `Board`, a `Board` depend on a `History` and we don't have the `History` yet when creating a `Game` then I chose to go the simplest way and add a conditional looking if it is the first move.

Also, it is important to note that the `Drop` class also changes the positionHashes in a similar way, but I did not really understood why. If this is important, the `Drop.finalizeAfter`must be changed too. I can do that if needed.

Lastly, I am not sure this will solve the [original bug](https://github.com/ornicar/lila/issues/7009) on custom positions, but hopefully it will. By the way, as it is noted there, for an unknown reason, the threefold is already working correctly on the initial position (that really surprised me ;) )