### PR TITLE
introduce rank and file types

### DIFF
--- a/src/main/scala/Actor.scala
+++ b/src/main/scala/Actor.scala
@@ -1,7 +1,6 @@
 package chess
 
 import format.Uci
-import Pos.posAt
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 
@@ -30,7 +29,7 @@ final case class Actor(
           } flatMap maybePromote
           def enpassant(horizontal: Direction): Option[Move] =
             for {
-              victimPos <- horizontal(pos).filter(_ => pos.y == color.passablePawnY)
+              victimPos <- horizontal(pos).filter(_ => pos.rank == color.passablePawnRank)
               _         <- board(victimPos).filter(v => v == !color - Pawn)
               targetPos <- horizontal(next)
               _ <- pawnDir(victimPos) flatMap pawnDir filter { vf =>
@@ -44,7 +43,7 @@ final case class Actor(
           def forward(p: Pos): Option[Move] =
             board.move(pos, p) map { move(p, _) } flatMap maybePromote
           def maybePromote(m: Move): Option[Move] =
-            if (m.dest.y == m.color.promotablePawnY)
+            if (m.dest.rank == m.color.promotablePawnRank)
               (m.after promote m.dest) map { b2 =>
                 m.copy(after = b2, promotion = Option(Queen))
               }
@@ -115,8 +114,8 @@ final case class Actor(
       if board(rookPos) contains color.rook
       if history.unmovedRooks.pos.contains(rookPos)
       // Check impeded castling.
-      newKingPos <- posAt(side.castledKingX, kingPos.y)
-      newRookPos <- posAt(side.castledRookX, rookPos.y)
+      newKingPos       = Pos(side.castledKingFile, kingPos.rank)
+      newRookPos       = Pos(side.castledRookFile, rookPos.rank)
       kingPath         = kingPos <-> newKingPos
       rookPath         = rookPos <-> newRookPos
       mustBeUnoccupied = (kingPath ++ rookPath).filter(_ != kingPos).filter(_ != rookPos)

--- a/src/main/scala/Board.scala
+++ b/src/main/scala/Board.scala
@@ -1,6 +1,5 @@
 package chess
 
-import Pos.posAt
 import variant.{ Crazyhouse, Variant }
 
 case class Board(
@@ -11,8 +10,7 @@ case class Board(
 ) {
 
   def apply(at: Pos): Option[Piece] = pieces get at
-
-  def apply(x: Int, y: Int): Option[Piece] = posAt(x, y) flatMap pieces.get
+  def apply(file: File, rank: Rank) = pieces get Pos(file, rank)
 
   lazy val actors: Map[Pos, Actor] = pieces map {
     case (pos, piece) => (pos, Actor(piece, pos, this))
@@ -134,7 +132,7 @@ case class Board(
   def unmovedRooks =
     UnmovedRooks {
       history.unmovedRooks.pos.filter(pos =>
-        apply(pos).exists(piece => piece.is(Rook) && piece.color.backrankY == pos.y)
+        apply(pos).exists(piece => piece.is(Rook) && piece.color.backRank == pos.rank)
       )
     }
 
@@ -143,8 +141,8 @@ case class Board(
       if (variant.allowsCastling) {
         val wkPos   = kingPosOf(White)
         val bkPos   = kingPosOf(Black)
-        val wkReady = wkPos.fold(false)(_.y == 1)
-        val bkReady = bkPos.fold(false)(_.y == 8)
+        val wkReady = wkPos.fold(false)(_.rank == Rank.First)
+        val bkReady = bkPos.fold(false)(_.rank == Rank.Eighth)
         def rookReady(color: Color, kPos: Option[Pos], left: Boolean) =
           kPos.fold(false) { kp =>
             actorsOf(color) exists { a =>

--- a/src/main/scala/Color.scala
+++ b/src/main/scala/Color.scala
@@ -8,9 +8,9 @@ sealed trait Color {
 
   def unary_! : Color
 
-  val passablePawnY: Int
-  val promotablePawnY: Int
-  val backrankY: Int
+  val passablePawnRank: Rank
+  val promotablePawnRank: Rank
+  val backRank: Rank
 
   val letter: Char
   val name: String
@@ -57,9 +57,9 @@ object Color {
 
     def unary_! = Black
 
-    val passablePawnY   = 5
-    val promotablePawnY = 8
-    val backrankY       = 1
+    val passablePawnRank   = Rank.Fifth
+    val promotablePawnRank = Rank.Eighth
+    val backRank           = Rank.First
 
     val letter = 'w'
     val name   = "white"
@@ -71,9 +71,9 @@ object Color {
 
     def unary_! = White
 
-    val passablePawnY   = 4
-    val promotablePawnY = 1
-    val backrankY       = 8
+    val passablePawnRank   = Rank.Fourth
+    val promotablePawnRank = Rank.First
+    val backRank           = Rank.Eighth
 
     val letter = 'b'
     val name   = "black"

--- a/src/main/scala/Divider.scala
+++ b/src/main/scala/Divider.scala
@@ -96,14 +96,16 @@ object Divider {
 
   private val mixednessRegions: List[List[Pos]] = {
     for {
-      y <- 1 to 7
-      x <- 1 to 7
+      y <- Rank.all.take(7)
+      x <- File.all.take(7)
     } yield {
       for {
-        dy <- 0 to 1
-        dx <- 0 to 1
-      } yield Pos.posAt(x + dx, y + dy)
-    }.toList.flatten
+        dy   <- 0 to 1
+        dx   <- 0 to 1
+        file <- x.offset(dx)
+        rank <- y.offset(dy)
+      } yield Pos(file, rank)
+    }.toList
   }.toList
 
   private def mixedness(board: Board): Int = {
@@ -118,7 +120,7 @@ object Divider {
             else black = black + 1
           }
         }
-        mix + score(white, black, region.head.y)
+        mix + score(white, black, region.head.rank.index + 1)
     }
   }
 }

--- a/src/main/scala/File.scala
+++ b/src/main/scala/File.scala
@@ -1,7 +1,7 @@
 package chess
 
 case class File private (val index: Int) extends AnyVal with Ordered[File] {
-  @inline def -(that: File): Int = index - that.index
+  @inline def -(that: File): Int           = index - that.index
   @inline override def compare(that: File) = this - that
 
   def offset(delta: Int): Option[File] =
@@ -9,10 +9,10 @@ case class File private (val index: Int) extends AnyVal with Ordered[File] {
     else None
 
   @inline def char: Char = (97 + index).toChar
-  override def toString = char.toString
+  override def toString  = char.toString
 
   @inline def upperCaseChar: Char = (65 + index).toChar
-  def toUpperCaseString = upperCaseChar.toString
+  def toUpperCaseString           = upperCaseChar.toString
 }
 
 object File {

--- a/src/main/scala/File.scala
+++ b/src/main/scala/File.scala
@@ -1,0 +1,37 @@
+package chess
+
+case class File private (val index: Int) extends AnyVal with Ordered[File] {
+  @inline def -(that: File): Int = index - that.index
+  @inline override def compare(that: File) = this - that
+
+  def offset(delta: Int): Option[File] =
+    if (-8 < delta && delta < 8) File(index + delta)
+    else None
+
+  @inline def char: Char = (97 + index).toChar
+  override def toString = char.toString
+
+  @inline def upperCaseChar: Char = (65 + index).toChar
+  def toUpperCaseString = upperCaseChar.toString
+}
+
+object File {
+  def apply(index: Int): Option[File] =
+    if (0 <= index && index < 8) Some(new File(index))
+    else None
+
+  @inline def of(pos: Pos): File = new File(pos.x - 1)
+
+  def fromChar(ch: Char): Option[File] = apply(ch.toInt - 97)
+
+  val A = new File(0)
+  val B = new File(1)
+  val C = new File(2)
+  val D = new File(3)
+  val E = new File(4)
+  val F = new File(5)
+  val G = new File(6)
+  val H = new File(7)
+
+  val all = List(A, B, C, D, E, F, G, H)
+}

--- a/src/main/scala/Hash.scala
+++ b/src/main/scala/Hash.scala
@@ -83,7 +83,7 @@ object Hash {
       else hactors
 
     val hep = situation.enPassantSquare.fold(hcastling) { pos =>
-      hcastling ^ table.enPassantMasks(pos.x - 1)
+      hcastling ^ table.enPassantMasks(pos.file.index)
     }
 
     // Hash in special three-check data.

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -11,7 +11,8 @@ object InsufficientMatingMaterial {
   def nonKingPieces(board: Board) = board.pieces filter (_._2.role != King)
 
   def bishopsOnOppositeColors(board: Board) =
-    (board.pieces collect { case (pos, Piece(_, Bishop)) => pos.isLight } toList).distinct.lengthCompare(2) == 0
+    (board.pieces collect { case (pos, Piece(_, Bishop)) => pos.isLight } toList).distinct
+    .lengthCompare(2) == 0
 
   /*
    * Returns true if a pawn cannot progress forward because it is blocked by a pawn

--- a/src/main/scala/Piece.scala
+++ b/src/main/scala/Piece.scala
@@ -31,9 +31,9 @@ case class Piece(color: Color, role: Role) {
   def eyesMovable(from: Pos, to: Pos): Boolean =
     if (role == Pawn) Piece.pawnEyes(color, from, to) || {
       (from ?| to) && {
-        val dy = to.y - from.y
-        if (color.white) (dy == 1 || (from.y <= 2 && dy == 2))
-        else (dy == -1 || (from.y >= 7 && dy == -2))
+        val dy = to.rank - from.rank
+        if (color.white) (dy == 1 || (from.rank <= Rank.Second && dy == 2))
+        else (dy == -1 || (from.rank >= Rank.Seventh && dy == -2))
       }
     }
     else eyes(from, to)
@@ -49,7 +49,7 @@ object Piece {
     }
 
   private def pawnEyes(color: Color, from: Pos, to: Pos) =
-    (from xDist to) == 1 && (to.y - from.y) == {
+    (from xDist to) == 1 && (to.rank - from.rank) == {
       if (color.white) 1 else -1
     }
 }

--- a/src/main/scala/Pos.scala
+++ b/src/main/scala/Pos.scala
@@ -42,9 +42,9 @@ sealed case class Pos private (x: Int, y: Int, piotr: Char) {
 
   def isLight: Boolean = (x + y) % 2 == 1
 
-  val file     = Pos xToString x
-  val rank     = y.toString
-  val key      = file + rank
+  @inline def file = File of this
+  @inline def rank = Rank of this
+  val key      = file.toString + rank.toString
   val piotrStr = piotr.toString
 
   override val toString = key
@@ -55,13 +55,13 @@ sealed case class Pos private (x: Int, y: Int, piotr: Char) {
 object Pos {
   val posCache = new Array[Pos](64)
 
+  def apply(file: File, rank: Rank): Pos = posCache(file.index + 8 * rank.index)
+
   def posAt(x: Int, y: Int): Option[Pos] =
     if (x < 1 || x > 8 || y < 1 || y > 8) None
     else posCache.lift(x + 8 * y - 9)
 
   def posAt(key: String): Option[Pos] = allKeys get key
-
-  def xToString(x: Int) = (96 + x).toChar.toString
 
   def piotr(c: Char): Option[Pos] = allPiotrs get c
 

--- a/src/main/scala/Pos.scala
+++ b/src/main/scala/Pos.scala
@@ -44,8 +44,8 @@ sealed case class Pos private (x: Int, y: Int, piotr: Char) {
 
   @inline def file = File of this
   @inline def rank = Rank of this
-  val key      = file.toString + rank.toString
-  val piotrStr = piotr.toString
+  val key          = file.toString + rank.toString
+  val piotrStr     = piotr.toString
 
   override val toString = key
 

--- a/src/main/scala/Rank.scala
+++ b/src/main/scala/Rank.scala
@@ -1,0 +1,35 @@
+package chess
+
+case class Rank private (val index: Int) extends AnyVal with Ordered[Rank] {
+  @inline def -(that: Rank): Int = index - that.index
+  @inline override def compare(that: Rank) = this - that
+
+  def offset(delta: Int): Option[Rank] =
+    if (-8 < delta && delta < 8) Rank(index + delta)
+    else None
+
+  @inline def char: Char = (49 + index).toChar
+  override def toString = char.toString
+}
+
+object Rank {
+  def apply(index: Int): Option[Rank] =
+    if (0 <= index && index < 8) Some(new Rank(index))
+    else None
+
+  @inline def of(pos: Pos): Rank = new Rank(pos.y - 1)
+
+  def fromChar(ch: Char): Option[Rank] = apply(ch.toInt - 49)
+
+  val First   = new Rank(0)
+  val Second  = new Rank(1)
+  val Third   = new Rank(2)
+  val Fourth  = new Rank(3)
+  val Fifth   = new Rank(4)
+  val Sixth   = new Rank(5)
+  val Seventh = new Rank(6)
+  val Eighth  = new Rank(7)
+
+  val all = List(First, Second, Third, Fourth, Fifth, Sixth, Seventh, Eighth)
+  val allReversed: List[Rank] = all.reverse
+}

--- a/src/main/scala/Rank.scala
+++ b/src/main/scala/Rank.scala
@@ -1,7 +1,7 @@
 package chess
 
 case class Rank private (val index: Int) extends AnyVal with Ordered[Rank] {
-  @inline def -(that: Rank): Int = index - that.index
+  @inline def -(that: Rank): Int           = index - that.index
   @inline override def compare(that: Rank) = this - that
 
   def offset(delta: Int): Option[Rank] =
@@ -9,7 +9,7 @@ case class Rank private (val index: Int) extends AnyVal with Ordered[Rank] {
     else None
 
   @inline def char: Char = (49 + index).toChar
-  override def toString = char.toString
+  override def toString  = char.toString
 }
 
 object Rank {
@@ -30,6 +30,6 @@ object Rank {
   val Seventh = new Rank(6)
   val Eighth  = new Rank(7)
 
-  val all = List(First, Second, Third, Fourth, Fifth, Sixth, Seventh, Eighth)
+  val all                     = List(First, Second, Third, Fourth, Fifth, Sixth, Seventh, Eighth)
   val allReversed: List[Rank] = all.reverse
 }

--- a/src/main/scala/Side.scala
+++ b/src/main/scala/Side.scala
@@ -2,8 +2,8 @@ package chess
 
 sealed trait Side {
 
-  def castledKingX: Int
-  def castledRookX: Int
+  def castledKingFile: File
+  def castledRookFile: File
 
   def tripToRook: (Pos, Board) => List[Pos]
 }
@@ -20,15 +20,15 @@ object Side {
 
 case object KingSide extends Side {
 
-  val castledKingX = 7
-  val castledRookX = 6
+  val castledKingFile = File.G
+  val castledRookFile = File.F
 
   val tripToRook: (Pos, Board) => List[Pos] = (pos, board) => pos >| board.pieces.contains
 }
 case object QueenSide extends Side {
 
-  val castledKingX = 3
-  val castledRookX = 4
+  val castledKingFile = File.C
+  val castledRookFile = File.D
 
   val tripToRook: (Pos, Board) => List[Pos] = (pos, board) => pos |< board.pieces.contains
 }

--- a/src/main/scala/Situation.scala
+++ b/src/main/scala/Situation.scala
@@ -85,11 +85,11 @@ case class Situation(board: Board, color: Color) {
       case Some(move: Uci.Move) =>
         if (
           move.dest.yDist(move.orig) == 2 &&
-          board.actorAt(move.dest).exists(_.piece.is(Pawn)) &&
+          board(move.dest).exists(_.is(Pawn)) &&
           List(
-            Pos.posAt(move.dest.x - 1, color.passablePawnY),
-            Pos.posAt(move.dest.x + 1, color.passablePawnY)
-          ).flatten.flatMap(board.actorAt).exists(_.piece == color.pawn)
+            move.dest.file.offset(-1),
+            move.dest.file.offset(1)
+          ).flatten.flatMap(board(_, color.passablePawnRank)).exists(_ == color.pawn)
         )
           moves.values.flatten.find(_.enpassant).map(_.dest)
         else None

--- a/src/main/scala/format/Forsyth.scala
+++ b/src/main/scala/format/Forsyth.scala
@@ -44,7 +44,7 @@ object Forsyth {
                   rookPos <- (ch.toLower match {
                       case 'k'  => rooks.reverse.find(_ ?> kingPos)
                       case 'q'  => rooks.find(_ ?< kingPos)
-                      case file => rooks.find(_.file == file.toString)
+                      case file => rooks.find(_.file.char == file)
                     })
                   side <- Side.kingRookSide(kingPos, rookPos)
                 } yield (c.add(color, side), r + rookPos)).getOrElse((c, r))
@@ -235,10 +235,10 @@ object Forsyth {
     {
       // castling rights with inner rooks are represented by their file name
       (if (board.castles.whiteKingSide && wr.nonEmpty && wur.nonEmpty)
-         (if (wur contains wr.max) "K" else wur.max.file.toUpperCase)
+         (if (wur contains wr.max) "K" else wur.max.file.toUpperCaseString)
        else "") +
         (if (board.castles.whiteQueenSide && wr.nonEmpty && wur.nonEmpty)
-           (if (wur contains wr.min) "Q" else wur.min.file.toUpperCase)
+           (if (wur contains wr.min) "Q" else wur.min.file.toUpperCaseString)
          else "") +
         (if (board.castles.blackKingSide && br.nonEmpty && bur.nonEmpty)
            (if (bur contains br.max) "k" else bur.max.file)

--- a/src/main/scala/format/UciCharPair.scala
+++ b/src/main/scala/format/UciCharPair.scala
@@ -13,7 +13,7 @@ object UciCharPair {
   def apply(uci: Uci): UciCharPair =
     uci match {
       case Uci.Move(orig, dest, None)       => UciCharPair(toChar(orig), toChar(dest))
-      case Uci.Move(orig, dest, Some(role)) => UciCharPair(toChar(orig), toChar(dest.x, role))
+      case Uci.Move(orig, dest, Some(role)) => UciCharPair(toChar(orig), toChar(dest.file, role))
       case Uci.Drop(role, pos) =>
         UciCharPair(
           toChar(pos),
@@ -22,8 +22,6 @@ object UciCharPair {
     }
 
   private[format] object implementation {
-
-    type File = Int
 
     val charShift = 35        // Start at Char(35) == '#'
     val voidChar  = 33.toChar // '!'. We skipped Char(34) == '"'.
@@ -38,8 +36,8 @@ object UciCharPair {
 
     val promotion2charMap: Map[(File, PromotableRole), Char] = for {
       (role, index) <- Role.allPromotable.zipWithIndex.to(Map)
-      file          <- 1 to 8
-    } yield (file, role) -> (charShift + pos2charMap.size + index * 8 + (file - 1)).toChar
+      file          <- File.all
+    } yield (file, role) -> (charShift + pos2charMap.size + index * 8 + file.index).toChar
 
     def toChar(file: File, prom: PromotableRole) =
       promotion2charMap.getOrElse(file -> prom, voidChar)

--- a/src/main/scala/format/Visual.scala
+++ b/src/main/scala/format/Visual.scala
@@ -45,9 +45,10 @@ object Visual {
           (pos, char)
         })
     }
-    for (y <- 8 to 1 by -1) yield {
-      for (x <- 1 to 8) yield {
-        posAt(x, y) flatMap markedPoss.get getOrElse board(x, y).fold(' ')(_ forsyth)
+    for (y <- Rank.allReversed) yield {
+      for (x <- File.all) yield {
+        val pos = Pos(x, y)
+        markedPoss.get(pos) getOrElse board(pos).fold(' ')(_ forsyth)
       }
     } mkString
   } map { """\s*$""".r.replaceFirstIn(_, "") } mkString "\n"

--- a/src/main/scala/format/pgn/Dumper.scala
+++ b/src/main/scala/format/pgn/Dumper.scala
@@ -11,7 +11,7 @@ object Dumper {
         if (orig ?> dest) "O-O-O" else "O-O"
 
       case _ if enpassant =>
-        orig.file + 'x' + dest.key
+        orig.file.toString + "x" + dest.key
 
       case (promotion, Pawn) =>
         (if (captures) s"${orig.file}x" else "") +
@@ -34,11 +34,11 @@ object Dumper {
         val disambiguation = if (candidates.isEmpty) {
           ""
         } else if (!candidates.exists(_ ?| orig)) {
-          orig.file
+          orig.file.toString
         } else if (!candidates.exists(_ ?- orig)) {
-          orig.rank
+          orig.rank.toString
         } else {
-          orig.file + orig.rank
+          orig.key
         }
 
         s"${role.pgn}$disambiguation${if (captures) "x" else ""}${dest.key}"

--- a/src/main/scala/format/pgn/parsingModel.scala
+++ b/src/main/scala/format/pgn/parsingModel.scala
@@ -60,9 +60,12 @@ case class Std(
   def move(situation: Situation): Validated[String, chess.Move] =
     situation.board.pieces.foldLeft(none[chess.Move]) {
       case (None, (pos, piece))
-          if piece.color == situation.color && piece.role == role && compare(file, pos.x) && compare(
+          if piece.color == situation.color && piece.role == role && compare(
+            file,
+            pos.file.index + 1
+          ) && compare(
             rank,
-            pos.y
+            pos.rank.index + 1
           ) && piece.eyesMovable(pos, dest) =>
         val a = Actor(piece, pos, situation.board)
         a trustedMoves false find { m =>

--- a/src/main/scala/variant/Crazyhouse.scala
+++ b/src/main/scala/variant/Crazyhouse.scala
@@ -25,7 +25,7 @@ case object Crazyhouse
     (!strict || (pieces.count(_ is Pawn) <= 16 && pieces.sizeIs <= 32))
   }
 
-  private def canDropPawnOn(pos: Pos) = pos.y != 1 && pos.y != 8
+  private def canDropPawnOn(pos: Pos) = pos.rank != Rank.First && pos.rank != Rank.Eighth
 
   override def drop(situation: Situation, role: Role, pos: Pos): Validated[String, Drop] =
     for {

--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -1,8 +1,6 @@
 package chess
 package variant
 
-import chess.Pos._
-
 case object Horde
     extends Variant(
       id = 8,
@@ -21,21 +19,16 @@ case object Horde
     val frontPawns = List(Pos.B5, Pos.C5, Pos.F5, Pos.G5).map { _ -> White.pawn }
 
     val whitePawnsHorde = frontPawns ++ (for {
-      x <- 1 to 8
-      y <- 1 to 4
-    } yield Pos.posAt(x, y) map (_ -> White.pawn)).flatten toMap
+      x <- File.all
+      y <- Rank.all.take(4)
+    } yield (Pos(x, y) -> White.pawn)) toMap
 
-    val blackPieces = (for (y <- 7 to 8; x <- 1 to 8) yield {
-      posAt(x, y) map { pos =>
-        (
-          pos,
-          y match {
-            case 8 => Black - backRank(x - 1)
-            case 7 => Black.pawn
-          }
-        )
-      }
-    }).flatten.toMap
+    val blackPieces = (for (y <- List(Rank.Seventh, Rank.Eighth); x <- File.all) yield {
+      Pos(x, y) -> (y match {
+        case Rank.Eighth  => Black - backRank(x.index)
+        case Rank.Seventh => Black.pawn
+      })
+    }).toMap
 
     blackPieces ++ whitePawnsHorde
   }
@@ -122,6 +115,6 @@ case object Horde
   }
 
   override def isUnmovedPawn(color: Color, pos: Pos) =
-    if (color.white) pos.y <= 2
-    else pos.y == 7
+    if (color.white) pos.rank <= Rank.Second
+    else pos.rank == Rank.Seventh
 }

--- a/src/main/scala/variant/RacingKings.scala
+++ b/src/main/scala/variant/RacingKings.scala
@@ -43,7 +43,7 @@ case object RacingKings
   override def opponentHasInsufficientMaterial(situation: Situation) = false
 
   private def reachedGoal(board: Board, color: Color) =
-    board.kingPosOf(color) exists (_.y == 8)
+    board.kingPosOf(color) exists (_.rank == Rank.Eighth)
 
   private def reachesGoal(move: Move) =
     reachedGoal(move.situationAfter.board, move.piece.color)

--- a/src/test/scala/PerftTest.scala
+++ b/src/test/scala/PerftTest.scala
@@ -7,7 +7,7 @@ class PerftTest extends ChessTest {
   def perft(game: Game, depth: Int): Int = {
     if (depth > 0)
       game.situation.moves.values.flatten.foldLeft(0)((p, move) =>
-        if (move.piece.role == Pawn && (move.dest.y == 1 || move.dest.y == 8))
+        if (move.piece.role == Pawn && (move.dest.rank == Rank.First || move.dest.rank == Rank.Eighth))
           p + perft(game.apply(move.withPromotion(Option(Queen)).get), depth - 1)
             + perft(game.apply(move.withPromotion(Option(Rook)).get), depth - 1)
             + perft(game.apply(move.withPromotion(Option(Bishop)).get), depth - 1)


### PR DESCRIPTION
a step towards #205

already proves quite useful because

```
(x: Int, y: Int) => Option[Pos]
```

but

```
(file: File, rank: Rank) => Pos
```