### PR TITLE
fix result-only pgn rendering

### DIFF
--- a/src/main/scala/format/pgn/model.scala
+++ b/src/main/scala/format/pgn/model.scala
@@ -40,8 +40,11 @@ case class Pgn(
       if (initial.comments.nonEmpty) initial.comments.mkString("{ ", " } { ", " }\n")
       else ""
     val turnStr = turns mkString " "
-    val endStr  = tags(_.Result) | ""
-    s"$tags\n\n$initStr$turnStr $endStr"
+    val resultStr = tags(_.Result) | ""
+    val endStr =
+      if (turnStr.nonEmpty) s" $resultStr"
+      else resultStr
+    s"$tags\n\n$initStr$turnStr$endStr"
   }.trim
 
   override def toString = render

--- a/src/test/scala/format/pgn/RenderTest.scala
+++ b/src/test/scala/format/pgn/RenderTest.scala
@@ -262,7 +262,7 @@ opening theory } 10. Bxc6 (10. O-O Bxc3 11. Bxc6 Bxb2 12. Bxb7 Bxa1 13.
       )
       pgn.toString must_== """[Result "0-1"]
 
- 0-1"""
+0-1"""
     }
   }
 


### PR DESCRIPTION
removes the extra space before the result, if the game has no moves