### PR TITLE
Set startAtTurn when creating Game from FEN

### DIFF
--- a/src/main/scala/Game.scala
+++ b/src/main/scala/Game.scala
@@ -116,7 +116,8 @@ object Game {
             },
             color = parsed.situation.color
           ),
-          turns = parsed.turns
+          turns = parsed.turns,
+          startedAtTurn = parsed.turns
         )
       }
   }


### PR DESCRIPTION
Fixes ornicar/lila#6497

(Found via WandererXII/lishogi#317)

To be safe, I also checked all the usages of this in lila and I'm pretty confident none of them rely on the incorrect previous behavior.

Also allows removing the special handling for this in [swiss](https://github.com/ornicar/lila/blob/1cacc2706fe2d2dd64ebc3a8b8044d99cf83d2b8/modules/swiss/src/main/SwissDirector.scala#L92) and [arena](https://github.com/ornicar/lila/blob/1cacc2706fe2d2dd64ebc3a8b8044d99cf83d2b8/modules/tournament/src/main/AutoPairing.scala#L34) game creation (which currently also always ignore the starting turn from the FEN but at least set it to 1 when it's black to start).