### PR TITLE
River Deep Mountain High Variant.

### DIFF
--- a/src/main/scala/Divider.scala
+++ b/src/main/scala/Divider.scala
@@ -101,8 +101,8 @@ object Divider {
       x <- File.all.take(7)
     } yield {
       for {
-        dy <- 0 to 1
-        dx <- 0 to 1
+        dy   <- 0 to 1
+        dx   <- 0 to 1
         file <- x.offset(dx)
         rank <- y.offset(dy)
       } yield Pos(file, rank)

--- a/src/main/scala/variant/RiverDeepMountainHigh.scala
+++ b/src/main/scala/variant/RiverDeepMountainHigh.scala
@@ -1,0 +1,42 @@
+package chess
+package variant
+
+import chess.File._
+import chess.Rank._
+
+case object RiverDeepMountainHigh
+    extends Variant(
+      id = 10,
+      key = "river-deep-mountain-high",
+      name = "River Deep Mountain High",
+      shortName = "RD/MH",
+      title =
+        "Knights can't move to the sides of the board (river). Rooks can't move across the 4 centre squares (mountain). Created by Lindosa & Araujo",
+      standardInitialPosition = true
+    ) {
+
+  def pieces = Standard.pieces
+
+  // In this variant, Knights can't move to the sides and Rooks can't move across the 4 centre squares
+  override def validMoves(situation: Situation) = {
+    val allMoves = super.validMoves(situation)
+    val filteredMoves = allMoves.view mapValues (_.filterNot(move => {
+      KnightIsBlockedByRiver(move) || RookIsBlockedByMountain(move)
+    }))
+    filteredMoves.to(Map)
+  }
+
+  private def KnightIsBlockedByRiver(m: Move) = (m.piece is Knight) && isRiver(m.dest)
+
+  private def RookIsBlockedByMountain(m: Move) = (m.piece is Rook) && blockedByMountain(m.orig, m.dest)
+
+  private def isRiver(pos: Pos): Boolean =
+    Set(A, H).contains(pos.file) || Set(First, Eighth).contains(pos.rank)
+
+  private def blockedByMountain(from: Pos, to: Pos): Boolean =
+    if (from ?- to && (Set(Fourth, Fifth) contains from.rank)) {                       // horizontal movement
+      (from.file < F && C < to.file) || (to.file < F && C < from.file)                 // mountain between from and to
+    } else if (from ?| to && (Set(D, E) contains from.file)) {                         // vertical movement
+      (from.rank < Sixth && Third < to.rank) || (to.rank < Sixth && Third < from.rank) // mountain between from and to
+    } else false
+}

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -19,16 +19,17 @@ abstract class Variant private[variant] (
 
   def pieces: Map[Pos, Piece]
 
-  def standard      = this == Standard
-  def chess960      = this == Chess960
-  def fromPosition  = this == FromPosition
-  def kingOfTheHill = this == KingOfTheHill
-  def threeCheck    = this == ThreeCheck
-  def antichess     = this == Antichess
-  def atomic        = this == Atomic
-  def horde         = this == Horde
-  def racingKings   = this == RacingKings
-  def crazyhouse    = this == Crazyhouse
+  def standard              = this == Standard
+  def chess960              = this == Chess960
+  def fromPosition          = this == FromPosition
+  def kingOfTheHill         = this == KingOfTheHill
+  def threeCheck            = this == ThreeCheck
+  def antichess             = this == Antichess
+  def atomic                = this == Atomic
+  def horde                 = this == Horde
+  def racingKings           = this == RacingKings
+  def crazyhouse            = this == Crazyhouse
+  def riverDeepMountainHigh = this == RiverDeepMountainHigh
 
   def exotic = !standard
 
@@ -216,7 +217,8 @@ object Variant {
     Antichess,
     Atomic,
     Horde,
-    RacingKings
+    RacingKings,
+    RiverDeepMountainHigh
   )
   val byId = all map { v =>
     (v.id, v)

--- a/src/test/scala/RiverDeepMountainHighVariantTest.scala
+++ b/src/test/scala/RiverDeepMountainHighVariantTest.scala
@@ -1,0 +1,99 @@
+package chess
+
+import chess.Pos._
+import chess.format.FEN
+import chess.variant.RiverDeepMountainHigh
+import org.specs2.matcher.ValidatedMatchers
+
+class RiverDeepMountainHighVariantTest extends ChessTest with ValidatedMatchers {
+
+  "RiverDeepMountainHigh " should {
+
+    "Not allow a knight to be move to the river" in {
+      val game = Game(RiverDeepMountainHigh).playMoves((E2, E4), (F7, F5))
+
+      val invalidGame = game flatMap (_.playMove(B1, A3))
+      invalidGame must beInvalid("Piece on b1 cannot move to a3")
+    }
+
+    "Not allow a knight to checkmate on the river" in {
+      val position = FEN("7k/8/6N1/8/8/8/8/K7 w")
+      val game     = fenToGame(position, RiverDeepMountainHigh)
+
+      val invalidGame = game flatMap (_.playMove(G6, H8))
+      invalidGame must beInvalid("Piece on g6 cannot move to h8")
+    }
+
+    "Allow a knight to ignore checkmate on the river" in {
+      val position = FEN("7k/8/6N1/8/8/8/8/K7 w")
+      val game     = fenToGame(position, RiverDeepMountainHigh)
+
+      val validGame = game flatMap (_.playMove(G6, E5))
+      validGame must beValid
+    }
+
+    "Not allow the Rook to pass through the mountain horizontally" in {
+      val position = FEN("7k/8/8/8/R7/8/8/7K")
+      val game     = fenToGame(position, RiverDeepMountainHigh)
+
+      val invalidGame = game flatMap (_.playMove(A4, F4))
+      invalidGame must beInvalid("Piece on a4 cannot move to f4")
+    }
+
+    "Not allow the Rook to pass through the mountain vertically" in {
+      val position = FEN("7k/3R4/8/8/8/8/8/7K")
+      val game     = fenToGame(position, RiverDeepMountainHigh)
+
+      val invalidGame = game flatMap (_.playMove(D7, D2))
+      invalidGame must beInvalid("Piece on d7 cannot move to d2")
+    }
+
+    "Not allow the Rook to land on the mountain horizontally" in {
+      val position = FEN("7k/8/8/8/R7/8/8/7K")
+      val game     = fenToGame(position, RiverDeepMountainHigh)
+
+      val invalidGame = game flatMap (_.playMove(A4, D4))
+      invalidGame must beInvalid("Piece on a4 cannot move to d4")
+    }
+
+    "Not allow the Rook to land on the mountain vertically" in {
+      val position = FEN("7k/3R4/8/8/8/8/8/7K")
+      val game     = fenToGame(position, RiverDeepMountainHigh)
+
+      val invalidGame = game flatMap (_.playMove(D7, D5))
+      invalidGame must beInvalid("Piece on d7 cannot move to d5")
+    }
+
+    "Allow the Rook to move outside the mountain horizontally" in {
+      val position = FEN("7k/8/8/8/8/R7/8/7K")
+      val game     = fenToGame(position, RiverDeepMountainHigh)
+
+      val validGame = game flatMap (_.playMove(A3, E3))
+      validGame must beValid
+    }
+
+    "Allow the Rook to move outside the mountain vertically" in {
+      val position = FEN("7k/2R5/8/8/8/8/8/7K")
+      val game     = fenToGame(position, RiverDeepMountainHigh)
+
+      val validGame = game flatMap (_.playMove(C7, C4))
+      validGame must beValid
+    }
+
+    "Allow the Queen to land on the mountain vertically" in {
+      val position = FEN("7k/3Q4/8/8/8/8/8/7K")
+      val game     = fenToGame(position, RiverDeepMountainHigh)
+
+      val validGame = game flatMap (_.playMove(D7, D5))
+      validGame must beValid
+    }
+
+    "Allow the Queen to pass through the mountain vertically" in {
+      val position = FEN("7k/3Q4/8/8/8/8/8/7K")
+      val game     = fenToGame(position, RiverDeepMountainHigh)
+
+      val validGame = game flatMap (_.playMove(D7, D3))
+      validGame must beValid
+    }
+  }
+}


### PR DESCRIPTION
Added a new variant "River Deep Mountain High" (RD/MH).
This variant largely follows standard chess rules with a couple of subtle differences:

Knights can't move to the sides of the board(ranks 1 and 8, files A and H) because there is a river.
Rooks can't move across the center squares of the board {D4, D5, E4, E5} due to a mountain.
Queens and other pieces are unaffected.
Created by Lindosa-Araujo.