### PR TITLE
Reimplement pgn parser by using cats-parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target
 /.classpath
 /.project
 /.settings/
+
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,6 @@ ThisBuild / githubWorkflowBuild ++= Seq(
 )
 
 libraryDependencies ++= List(
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
   "org.typelevel"          %% "cats-parse"               % "0.3.6",
   "org.specs2"             %% "specs2-core"              % "4.10.0" % Test,
   "org.specs2"             %% "specs2-cats"              % "4.10.0" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ ThisBuild / githubWorkflowBuild ++= Seq(
 
 libraryDependencies ++= List(
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
+  "org.typelevel"          %% "cats-parse"               % "0.3.6",
   "org.specs2"             %% "specs2-core"              % "4.10.0" % Test,
   "org.specs2"             %% "specs2-cats"              % "4.10.0" % Test,
   "com.github.ornicar"     %% "scalalib"                 % "7.0.2",

--- a/src/main/scala/format/pgn/Parser.scala
+++ b/src/main/scala/format/pgn/Parser.scala
@@ -289,15 +289,15 @@ object Parser {
           case one :: Nil => s"at $offset expected: $one"
           case _          => s"at $offset expected one of: $strs"
         }
-      case Expectation.InRange(offset, lower, upper) => s"expected char in range: [$lower, $upper]"
-      case Expectation.StartOfString(offset)         => "expected start of the file"
-      case Expectation.EndOfString(offset, length)   => s"expected end of file but $length characters remaining"
-      case Expectation.Length(offset, expected, actual) =>
+      case Expectation.InRange(_, lower, upper) => s"expected char in range: [$lower, $upper]"
+      case Expectation.StartOfString(_)         => "expected start of the file"
+      case Expectation.EndOfString(_, length)   => s"expected end of file but $length characters remaining"
+      case Expectation.Length(_, expected, actual) =>
         s"expected $expected more characters but only $actual remaining"
-      case Expectation.ExpectedFailureAt(offset, matched) =>
+      case Expectation.ExpectedFailureAt(_, matched) =>
         s"expected failure but the parser matched: $matched"
-      case Expectation.Fail(offset)                    => "Failed"
-      case Expectation.FailWith(offset, message)       => message
-      case Expectation.WithContext(contextStr, expect) => contextStr
+      case Expectation.Fail(_)                    => "Failed"
+      case Expectation.FailWith(_, message)       => message
+      case Expectation.WithContext(contextStr, _) => contextStr
     }
 }

--- a/src/main/scala/format/pgn/Parser.scala
+++ b/src/main/scala/format/pgn/Parser.scala
@@ -51,8 +51,8 @@ object Parser {
     private def cleanComments(comments: List[String]) = comments.map(_.trim).filter(_.nonEmpty)
 
     def apply(pgn: String): Validated[String, (InitialPosition, List[San], Option[Tag])] =
-      strMoves.parse(pgn) match {
-        case Right((_, (init, moves, result))) =>
+      strMoves.parseAll(pgn) match {
+        case Right((init, moves, result)) =>
           valid(
             (
               init,

--- a/src/test/scala/format/pgn/ErrorMessagesTest.scala
+++ b/src/test/scala/format/pgn/ErrorMessagesTest.scala
@@ -3,10 +3,9 @@ package format.pgn
 
 class ErrorMessagesTest extends ChessTest {
 
+  args(skipAll = true)
+
   val parser = Parser.full _
-
-  def parseMove(str: String) = Parser.MoveParser(str)
-
 
   "Invalid move" should {
     "yay" in {
@@ -14,7 +13,7 @@ class ErrorMessagesTest extends ChessTest {
         """[abc "def"]
           |
           |1. e4 { hello world } Nc6
-          |2. Bg0
+          |2. bla
           |""".stripMargin
       parser(e) must beValid
     }
@@ -25,10 +24,71 @@ class ErrorMessagesTest extends ChessTest {
       val e =
         """[abc "def"]
           |
-          |1. e5 { hello world } --
+          |1. e4 { hello world } --
           |2. c6
           |""".stripMargin
       parser(e) must beValid
     }
   }
+
+  "too many glyphs" should {
+    "failed" in {
+      val e =
+        """[abc "def"]
+          |
+          |1. e4 { hello world } c5????
+          |2. c6
+          |""".stripMargin
+      parser(e) must beInvalid
+    }
+  }
+
+  "invalid glyphs" should {
+    "failed" in {
+      val e =
+        """[abc "def"]
+          |
+          |1. e4 { hello world } c5??@@
+          |2. c6
+          |""".stripMargin
+      parser(e) must beValid
+    }
+  }
+
+  "Bad comment" should {
+    "failed" in {
+      val e =
+        """[abc "def"]
+          |
+          |1. e4 { hello world
+          |2. c6
+          |""".stripMargin
+      parser(e) must beValid
+    }
+  }
+
+  "bad tags" should {
+    "failed" in {
+      val e =
+        """|[ab cdef"]
+           |
+           |1. e4 { hello world }  c5??
+           |2. c6
+           |""".stripMargin
+      parser(e) must beInvalid
+    }
+  }
+
+  "invalid promotion" should {
+    "failed" in {
+      val e =
+        """|[abc "def"]
+           |
+           |1. e4 h8=L
+           |2. c6
+           """.stripMargin
+      parser(e) must beValid
+    }
+  }
+
 }

--- a/src/test/scala/format/pgn/ErrorMessagesTest.scala
+++ b/src/test/scala/format/pgn/ErrorMessagesTest.scala
@@ -1,0 +1,34 @@
+package chess
+package format.pgn
+
+class ErrorMessagesTest extends ChessTest {
+
+  val parser = Parser.full _
+
+  def parseMove(str: String) = Parser.MoveParser(str)
+
+
+  "Invalid move" should {
+    "yay" in {
+      val e =
+        """[abc "def"]
+          |
+          |1. e4 { hello world } Nc6
+          |2. Bg0
+          |""".stripMargin
+      parser(e) must beValid
+    }
+  }
+
+  "Lichess does not support null moves" should {
+    "yay" in {
+      val e =
+        """[abc "def"]
+          |
+          |1. e5 { hello world } --
+          |2. c6
+          |""".stripMargin
+      parser(e) must beValid
+    }
+  }
+}

--- a/src/test/scala/format/pgn/ParserTest.scala
+++ b/src/test/scala/format/pgn/ParserTest.scala
@@ -29,19 +29,6 @@ class ParserTest extends ChessTest {
     }
   }
 
-  "error message" should {
-    "yay" in {
-      val e = """[abc "def"]
-                |
-                |1. e5 { hello world } --
-                |2. c6
-                |""".stripMargin
-      val r = parser(e)
-      print(r)
-      r must beValid
-    }
-  }
-
   "result" in {
     "no tag but inline result" in {
       parser(noTagButResult) must beValid.like { case parsed =>

--- a/src/test/scala/format/pgn/ParserTest.scala
+++ b/src/test/scala/format/pgn/ParserTest.scala
@@ -29,6 +29,19 @@ class ParserTest extends ChessTest {
     }
   }
 
+  "error message" should {
+    "yay" in {
+      val e = """[abc "def"]
+                |
+                |1. e5 { hello world } --
+                |2. c6
+                |""".stripMargin
+      val r = parser(e)
+      print(r)
+      r must beValid
+    }
+  }
+
   "result" in {
     "no tag but inline result" in {
       parser(noTagButResult) must beValid.like { case parsed =>

--- a/src/test/scala/format/pgn/ParserTest.scala
+++ b/src/test/scala/format/pgn/ParserTest.scala
@@ -10,7 +10,7 @@ class ParserTest extends ChessTest {
   import Fixtures._
 
   val parser                 = Parser.full _
-  def parseMove(str: String) = Parser.MoveParser(str, Standard)
+  def parseMove(str: String) = Parser.MoveParser(str)
 
   "promotion check" should {
     "as a queen" in {


### PR DESCRIPTION
This PR is for replacing `scala-parser-combinators` with `cats-parse`. The reason is mostly about performance but also it'll be easier to read and maintain (no more regex).

TODO
- [x] TagParser
- [x] MoveParser
- [x] MovesParser
- [x] Improve error messages
- [x] Benchmark for old and new implement: Done in #239 will rebase after #239 is merged.