### PR TITLE
Use more games when perform ParserPerfTest

### DIFF
--- a/src/test/scala/format/pgn/Fixtures.scala
+++ b/src/test/scala/format/pgn/Fixtures.scala
@@ -2002,5 +2002,5 @@ val gamesForPerfTest = List(enpassantEP, enpassantEP2, recentChessCom, chessComC
   promoteRook, castleCheck1, castleCheck2, fromCrafty, withNag, fromTcec, fromLichessBadPromotion, fromTcecWithEngineOutput,
   fromPositionEmptyFen, chessbaseWeird, chessbaseArrows, commentsAndVariations, bySmartChess, android, chesskids, variations,
   caissa, handwritten, chessByPost, atomicRegression, atomicPromotion, weirdDashes, lichobile, overflow, overflow3,
-  crazyhouse1, crazyhouse2, crazyhouseNoVariantTag, stackOverflow, explorerPartialDate, withGlyphAnnotations) ++ prod500standard
+  crazyhouse1, crazyhouse2, crazyhouseNoVariantTag, stackOverflow, explorerPartialDate, withGlyphAnnotations)
 }

--- a/src/test/scala/format/pgn/Fixtures.scala
+++ b/src/test/scala/format/pgn/Fixtures.scala
@@ -1995,4 +1995,12 @@ val clonoNoExoticNotation = """
 1. e2e4 e7e5 2. Ng1f3 Nb8c6 3. c2c3 Ng8f6 4. d2d4 e5xd4 5. e4e5 Nf6d5 6. Qd1b3 Nd5b6 7. c3xd4 d7d5 8. Bc1e3 Bc8f5 9. a2a3 Qd8d7 10. Nb1d2 Bf8e7 11. Bf1e2 a7a6 12. Ra1c1 O-O 13. O-O f7f6 14. Rf1d1 Kg8h8 15. Nd2b1 Nc6a5 16. Qb3c3 Na5c4 17. Be2c4 Nb6c4 18. Nb1d2 b7b5 19. Nd2b3 Bf5g4 20. e5xf6 Bg4f3 21. f6xe7 Qd7g4 22. e7xf8=Q+ {[%clk 00:26:01]} Ra8f8 {[%clk 00:27:09]} 0-1
 """
 
+val gamesForPerfTest = List(enpassantEP, enpassantEP2, recentChessCom, chessComCrazyhouse, fromPosProdCloseChess,
+  fromChessProgrammingWiki, noTagButResult, inlineTags, whiteResignsInTags, whiteResignsInMoves, whiteResignsInTagsAndMoves,
+  festivalFigueira, crazyhouseFromProd, complete960, fromWikipedia, stLouisFischerandom, inlineComments, fromChessgames,
+  fromChessgamesWithEscapeChar, chessgamesWeirdComments, withDelimiters, withDelimitersOnNewLines, fromProd1, fromProd2,
+  promoteRook, castleCheck1, castleCheck2, fromCrafty, withNag, fromTcec, fromLichessBadPromotion, fromTcecWithEngineOutput,
+  fromPositionEmptyFen, chessbaseWeird, chessbaseArrows, commentsAndVariations, bySmartChess, android, chesskids, variations,
+  caissa, handwritten, chessByPost, atomicRegression, atomicPromotion, weirdDashes, lichobile, overflow, overflow3,
+  crazyhouse1, crazyhouse2, crazyhouseNoVariantTag, stackOverflow, explorerPartialDate, withGlyphAnnotations) ++ prod500standard
 }

--- a/src/test/scala/format/pgn/ParserPerfTest.scala
+++ b/src/test/scala/format/pgn/ParserPerfTest.scala
@@ -1,23 +1,18 @@
 package chess
 package format.pgn
 
+import cats.implicits._
+
 class ParserPerfTest extends ChessTest {
 
-  args(skipAll = true)
-
-  val nb         = 100
+  val nb         = Fixtures.gamesForPerfTest.length
   val iterations = 10
-  // val nb = 1
-  // val iterations = 1
-  val game =
-    "d4 Nf6 Nf3 Nc6 Nbd2 e6 e4 d6 c4 Qe7 Bd3 e5 d5 Nd4 Nxd4 exd4 O-O Bg4 f3 Bd7 Nb3 Qe5 Be2 c5 dxc6 bxc6 Qxd4 Qxd4+ Nxd4 Rb8 b3 Be7 Be3 Bd8 Rfd1 Bb6 Kf2 Ke7 Rd2 Ba5 Rd3 Bb6 Rad1 Rhd8 g4 h6 Bf4 g5 Bg3 h5 h3 h4 Bh2 Rb7 e5 dxe5 Bxe5 Ne8 Kg2 Bc7 Bxc7 Rxc7 Nf5+ Kf8 f4 gxf4 Nxh4 Ng7 Bf3 Ne6 Nf5 Nc5 Rd4 Ne6 Rd6 c5 h4 Ng7 Nxg7 Kxg7 g5 a5 Kf2 Kf8 Bc6 Ke7 Ba4 Bxa4 Rxd8 Bc6 h5 Ke6 h6 Be4 Rh8 Re7 Re1 Kf5 h7 Kg6 Rc8 Kxh7 Rxc5 a4 b4 Kg6 b5 f6 gxf6 Kxf6 b6 a3 Rc7 Rxc7 bxc7 Bb7 Re8 Kf5 c5 Ba6 Ra8 Bb7 Rf8+ Ke5 c6 Ba6 Ra8 Kd6 Rxa6 Kxc7 Kf3 Kb8 Kxf4 Kc8 Ke5 Kc7 Ke6 Kd8 Kd6 Ke8 Ra7 Kf8 c7 Kf7 c8=Q+ Kg6 Qg4+ Kf6 Ra8 Kf7 Qf5+ Kg7 Ra7+ Kg8 Qc8#"
 
-  def runOne = Parser.moves(game, variant.Standard)
-  def run: Unit = { for (i <- 1 to nb) runOne }
+  def run = Fixtures.gamesForPerfTest.traverse(Parser.full)
 
-  "playing a game" should {
+  "Parser perf" should {
     "many times" in {
-      runOne must beValid
+      run must beValid
       if (nb * iterations > 1) {
         println("warming up")
         run


### PR DESCRIPTION
This also enable `ParserPerfTest` when perform testing (removed `skipAll = true`). It just takes around 10 seconds so I don't think it is necessary to skip it.

I'll use results from this test to compare performance in #247.

I think it is better to use https://github.com/sbt/sbt-jmh or https://github.com/scalameter/scalameter. But after sort try I couldn't set them up. I'll probably try to work on that sometime in the future.

Update current output look like this in my machine (Macbook Pro 32GB ram, 2.6 GHz 6-Core Intel Core i7)

```
555 games in 328 ms
555 games in 331 ms
555 games in 287 ms
555 games in 293 ms
555 games in 283 ms
555 games in 333 ms
555 games in 281 ms
555 games in 282 ms
555 games in 281 ms
555 games in 277 ms
Average = 536 microseconds per game
          1865 games per second
```

Result after remove `prod500standard`:
```
55 games in 127 ms
55 games in 101 ms
55 games in 89 ms
55 games in 82 ms
55 games in 80 ms
55 games in 66 ms
55 games in 63 ms
55 games in 61 ms
55 games in 64 ms
55 games in 92 ms
Average = 1500 microseconds per game
          666 games per second
```