### PR TITLE
Reject files that havve invalid tags

### DIFF
--- a/src/main/scala/format/pgn/Parser.scala
+++ b/src/main/scala/format/pgn/Parser.scala
@@ -239,13 +239,13 @@ object Parser {
 
   object TagParser {
 
-    val tagName: P[String]      = R.alpha.rep.string
+    val tagName: P[String]      = R.alpha.rep.string.withContext("Tag name can only contains alphabet characters")
     val escapeDquote: P[String] = (P.char('\\') ~ R.dquote).as("\"")
     val valueChar: P[String]    = escapeDquote | P.charWhere(_ != '"').string
     val tagValue: P[String]     = valueChar.rep0.map(_.mkString).with1.surroundedBy(R.dquote)
     val tagContent: P[Tag]      = ((tagName <* R.wsp.rep) ~ tagValue).map(p => Tag(p._1, p._2))
     val tag: P[Tag]             = tagContent.between(P.char('['), P.char(']')) <* whitespace.rep0
-    val tags: P[Tags]           = tag.backtrack.rep.map(tags => Tags(tags.toList))
+    val tags: P0[Tags]          = tag.rep0.map(tags => Tags(tags))
 
     def apply(pgn: String): Validated[String, Tags] =
       tags.parse(pgn) match {

--- a/src/test/scala/format/pgn/ErrorMessagesTest.scala
+++ b/src/test/scala/format/pgn/ErrorMessagesTest.scala
@@ -8,7 +8,7 @@ class ErrorMessagesTest extends ChessTest {
   val parser = Parser.full _
 
   "Invalid move" should {
-    "yay" in {
+    "fail" in {
       val e =
         """[abc "def"]
           |
@@ -20,7 +20,7 @@ class ErrorMessagesTest extends ChessTest {
   }
 
   "Lichess does not support null moves" should {
-    "yay" in {
+    "fail" in {
       val e =
         """[abc "def"]
           |
@@ -32,7 +32,7 @@ class ErrorMessagesTest extends ChessTest {
   }
 
   "too many glyphs" should {
-    "failed" in {
+    "fail" in {
       val e =
         """[abc "def"]
           |
@@ -44,7 +44,7 @@ class ErrorMessagesTest extends ChessTest {
   }
 
   "invalid glyphs" should {
-    "failed" in {
+    "fail" in {
       val e =
         """[abc "def"]
           |
@@ -55,8 +55,8 @@ class ErrorMessagesTest extends ChessTest {
     }
   }
 
-  "Bad comment" should {
-    "failed" in {
+  "bad comment" should {
+    "fail" in {
       val e =
         """[abc "def"]
           |
@@ -67,15 +67,27 @@ class ErrorMessagesTest extends ChessTest {
     }
   }
 
-  "bad tags" should {
+  "invalid tags 1" should {
     "failed" in {
       val e =
-        """|[ab cdef"]
+        """|[ab "cdef]
            |
            |1. e4 { hello world }  c5??
            |2. c6
            |""".stripMargin
-      parser(e) must beInvalid
+      parser(e) must beValid
+    }
+  }
+
+  "invalid tags 2" should {
+    "failed" in {
+      val e =
+        """|[ab "cdef"]    [123]
+           |
+           |1. e4 { hello world }  c5??
+           |2. c6
+           |""".stripMargin
+      parser(e) must beValid
     }
   }
 

--- a/src/test/scala/format/pgn/Fixtures.scala
+++ b/src/test/scala/format/pgn/Fixtures.scala
@@ -113,7 +113,7 @@ mit -0.10 minimal Schwarz vorne sieht, ist doch die Remisbreite sehr hoch.}
 """
 
   val fromPosProdCloseChess = """
-[FEN "8/rnbqkbnr/pppppppp/8/8/PPPPPPPP/RNBQKBNR/8 w - - 0 1"]                                                                     [12/1807]
+[FEN "8/rnbqkbnr/pppppppp/8/8/PPPPPPPP/RNBQKBNR/8 w - - 0 1"]
 1. d4 d5 2. Nf4 Nf5 3. g4 g5 4. gxf5 exf5
 5. Nbd3 gxf4 6. Nxf4 Bxf4 7. exf4 Nd6 8. Bh4 Qd8
 9. Bd3 Kd7 10. Kf1 Kc8 11. Rg2 Kb8 12. Qe1 Bh5
@@ -1520,7 +1520,7 @@ val bySmartChess = """
 [White "Andersson, U"]
 [Black "Robatsch"]
 [Result "1-0"]
-[Annotator  "Krush, I]
+[Annotator  "Krush, I"]
 
 {
 http://www.smartchess.com/SmartChessOnline/default.htm


### PR DESCRIPTION
Close #253 

Below  is sample of error messages:
Example 1:
```
[ab "cdef"]     [123]
1. e4 { hello world }  c5??
2. c6
```

Error:
```
Cannot parse tags: [1.17]: Tag name can only contains alphabet characters

[ab "cdef"]    [123]
                    ^
[ab "cdef"]    [123]
```

Example 2:

```
[ab "cdef]
1. e4 { hello world }  c5??
2. c6
```

Error:
```
Cannot parse tags: [1.11]: expected: "

[ab "cdef] 
                 ^
[ab "cdef]
```

performance is also improved

```
55 games in 22 ms
55 games in 20 ms
55 games in 20 ms
55 games in 19 ms
55 games in 19 ms
55 games in 19 ms
55 games in 18 ms
55 games in 23 ms
55 games in 20 ms
55 games in 16 ms
Average = 356 microseconds per game
          2808 games per second
```