### PR TITLE
Evaluate situation.status only when we actually have clock

### DIFF
--- a/src/main/scala/Game.scala
+++ b/src/main/scala/Game.scala
@@ -69,7 +69,10 @@ case class Game(
     )
   }
 
-  private def applyClock(metrics: MoveMetrics, gameActive: => Boolean): Option[Clock.WithCompensatedLag[Clock]] =
+  private def applyClock(
+      metrics: MoveMetrics,
+      gameActive: => Boolean
+  ): Option[Clock.WithCompensatedLag[Clock]] =
     clock.map { prev =>
       {
         val c1 = metrics.frameLag.fold(prev)(prev.withFrameLag)

--- a/src/main/scala/Game.scala
+++ b/src/main/scala/Game.scala
@@ -69,7 +69,7 @@ case class Game(
     )
   }
 
-  private def applyClock(metrics: MoveMetrics, gameActive: Boolean): Option[Clock.WithCompensatedLag[Clock]] =
+  private def applyClock(metrics: MoveMetrics, gameActive: => Boolean): Option[Clock.WithCompensatedLag[Clock]] =
     clock.map { prev =>
       {
         val c1 = metrics.frameLag.fold(prev)(prev.withFrameLag)


### PR DESCRIPTION
If clock is not available, it's not necessary to perform relatively expensive evaluation of situation status.

Before:
```
sbt:scalachess> testOnly shogi chess.ReplayPerfTest
running tests
500 games in 3611 ms
500 games in 3491 ms
500 games in 3792 ms
500 games in 3448 ms
500 games in 3671 ms
Average = 7205 microseconds per game
          138 games per second
[info] ReplayPerfTest
[info] playing a game should
[info]   + many times
[info] Total for specification ReplayPerfTest
[info] Finished in 24 seconds, 918 ms
[info] 1 example, 0 failure, 0 error
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
```

After:
```
sbt:scalachess> testOnly shogi chess.ReplayPerfTest
running tests
500 games in 1352 ms
500 games in 1276 ms
500 games in 1222 ms
500 games in 1186 ms
500 games in 1181 ms
Average = 2486 microseconds per game
          402 games per second
[info] ReplayPerfTest
[info] playing a game should
[info]   + many times
[info] Total for specification ReplayPerfTest
[info] Finished in 10 seconds, 497 ms
[info] 1 example, 0 failure, 0 error
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
````