### PR TITLE
Implement Tiebreak.foldModifier

### DIFF
--- a/tiebreak/src/main/scala/Tiebreak.scala
+++ b/tiebreak/src/main/scala/Tiebreak.scala
@@ -56,7 +56,7 @@ object TournamentScore extends OpaqueFloat[TournamentScore]:
   extension (score: TournamentScore) def >=(other: TournamentScore): Boolean = score.value >= other.value
 
 sealed trait Tiebreak(val code: Code, val description: String):
-  def extendedCode: String = code
+  def extendedCode: String = foldModifier(code, _.extendedCode(code), _ => code)
   // compute players' tiebreak points based on the tournament and a list of previously computed tiebreak points
   def compute(tour: Tournament, previousPoints: PlayerPoints): PlayerPoints
 
@@ -110,7 +110,6 @@ case object NbBlackWins extends Tiebreak("BWG", "Number of wins with black"):
 
 case class SonnebornBerger(modifier: CutModifier)
     extends Tiebreak("SB", modifier.extendedDescription("Sonneborn-Berger")):
-  override def extendedCode: String = modifier.extendedCode(code)
   override def compute(tour: Tournament, previousPoints: PlayerPoints): PlayerPoints =
     tour.players.view
       .map: player =>
@@ -119,7 +118,6 @@ case class SonnebornBerger(modifier: CutModifier)
       .toMap
 
 case class Buchholz(modifier: CutModifier) extends Tiebreak("BH", modifier.extendedDescription("Buchholz")):
-  override def extendedCode: String = modifier.extendedCode(code)
   override def compute(tour: Tournament, previousPoints: PlayerPoints): PlayerPoints =
     tour.players.view
       .map: player =>
@@ -129,7 +127,6 @@ case class Buchholz(modifier: CutModifier) extends Tiebreak("BH", modifier.exten
 
 case class ForeBuchholz(modifier: CutModifier)
     extends Tiebreak("FB", modifier.extendedDescription("Fore Buchholz")):
-  override def extendedCode: String = modifier.extendedCode(code)
   def compute(tour: Tournament, previousPoints: PlayerPoints): PlayerPoints =
     tour.players.view
       .map: player =>
@@ -173,7 +170,6 @@ case object DirectEncounter extends Tiebreak("DE", "Direct encounter"):
 
 case class AverageRatingOfOpponents(modifier: CutModifier)
     extends Tiebreak("ARO", modifier.extendedDescription("Average rating of opponents")):
-  override def extendedCode: String = modifier.extendedCode(code)
   override def compute(tour: Tournament, previousPoints: PlayerPoints): PlayerPoints =
     tour.players.view
       .map: player =>
@@ -213,7 +209,6 @@ case class KoyaSystem(val limit: LimitModifier)
 
 case class SumOfProgressiveScores(modifier: CutModifier)
     extends Tiebreak("PS", modifier.extendedDescription("Sum of progressive scores")):
-  override def extendedCode: String = modifier.extendedCode(code)
   def compute(tour: Tournament, previousPoints: PlayerPoints): PlayerPoints =
     tour.players.view
       .map: player =>


### PR DESCRIPTION
An alternative way of getting `modifier` out of Tiebreaks. This is to avoid override `cutModifier` and `limitModifier` in sub cases.

This also re-implement `extendedCode` directly in `Tiebreak` trait (so no missing override needs to be worried).

p/s: it's a shame that we can't do (yet):

```scala
      case SumOfProgressiveScores(modifier) |
          AverageRatingOfOpponents(modifier) |
          SonnebornBerger(modifier) |
          Buchholz(modifier) |
          ForeBuchholz(modifier) =>
        f(modifier)
```