### PR TITLE
fix import parsing of TimeControl tag when chesscom is the source

### DIFF
--- a/core/src/main/scala/format/pgn/Tag.scala
+++ b/core/src/main/scala/format/pgn/Tag.scala
@@ -136,7 +136,7 @@ object Tags:
         else tag.copy(value = tag.value.replace("\"", "").trim)
 
   private val DateRegex = """(\d{4}|\?{4})\.(\d\d|\?\?)\.(\d\d|\?\?)""".r
-  private val SiteIsStrictRegex = """(?i)lichess\.org|chess\.com""".r.unanchored
+  private val SiteIsStrictRegex = """(?i)\b(?:lichess\.org|chess\.com)\b""".r.unanchored
 
 object Tag:
 


### PR DESCRIPTION
i suspect strict should be default, but this will make me happy