### PR TITLE
reject multiple checking steppers in strict validation

### DIFF
--- a/core/src/main/scala/Board.scala
+++ b/core/src/main/scala/Board.scala
@@ -154,6 +154,9 @@ case class Board(occupied: Bitboard, byColor: ByColor[Bitboard], byRole: ByRole[
   def sliders: Bitboard =
     bishops ^ rooks ^ queens
 
+  def steppers: Bitboard =
+    knights ^ kings ^ pawns
+
   def attacks(s: Square, attacker: Color): Boolean =
     attackers(s, attacker).nonEmpty
 

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -17,7 +17,7 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
     kingsAndBishopsOnlyOf, kingsAndKnightsOnly, kingsAndKnightsOnlyOf, kingsAndMinorsOnly,
     kingsOnly, kingsOnlyOf, kingsRooksAndMinorsOnly, knights, nbPieces, nonKingsOf, occupied,
     onlyKnights, onlyOf, pawns, piece, pieceAt, pieceMap as pieces, pieces as allPieces, piecesOf,
-    queens, rooks, sliderBlockers, sliders, white, count, contains
+    queens, rooks, sliderBlockers, sliders, steppers, white, count, contains
   }
   // format: on
 

--- a/core/src/main/scala/variant/Standard.scala
+++ b/core/src/main/scala/variant/Standard.scala
@@ -78,6 +78,7 @@ case object Standard
     val checkerCount = activeCheckers.count
     if checkerCount <= 1 then true
     else if checkerCount >= 3 then false
+    else if (activeCheckers & position.steppers).moreThanOne then false
     else
       (for
         firstChecker <- activeCheckers.first

--- a/test-kit/src/test/scala/VariantTest.scala
+++ b/test-kit/src/test/scala/VariantTest.scala
@@ -85,6 +85,15 @@ class VariantTest extends ChessTest:
       assert(game.variant.valid(game, true))
       assert(game.variant.valid(game, false))
 
+    test(
+      s"$variant when multiple steppers give check"
+    ):
+      val game = Fen
+        .read(variant, FullFen("2kq1r2/5rq1/1N1N4/N3N3/1KN5/N3B3/1N1N4/8 b k - 0 1"))
+        .get
+      assertNot(game.variant.valid(game, true))
+      assert(game.variant.valid(game, false))
+
   test("standard position pieces correctly"):
     assertEquals(
       Standard.initialPieces,


### PR DESCRIPTION
sf move generation (generally, but not in all cases) assumes that it can evade check by capturing a stepping checker, like QxN in https://lichess.org/editor/2kq1r2/5rq1/1N1N4/N3N3/1KN5/N3B3/1N1N4/8_b_k_-_0_1. reject such positions in strict validation.