### PR TITLE
Antichess insufficient material with opposite-coloured bishops

### DIFF
--- a/core/src/main/scala/Bitboard.scala
+++ b/core/src/main/scala/Bitboard.scala
@@ -128,7 +128,7 @@ object Bitboard:
       do
         builder += b.lsb
         b &= (b - 1L)
-      builder.result
+      builder.result()
 
     def toSet: Set[Square] =
       squares.toSet
@@ -187,7 +187,7 @@ object Bitboard:
       do
         if f(b.lsb) then builder += b.lsb
         b &= (b - 1L)
-      builder.result
+      builder.result()
 
     def withFilter(f: Square => Boolean): List[Square] =
       filter(f)
@@ -224,7 +224,7 @@ object Bitboard:
       do
         builder ++= f(b.lsb)
         b &= (b - 1L)
-      builder.result
+      builder.result()
 
     def map[B](f: Square => B): List[B] =
       var b = a
@@ -233,7 +233,7 @@ object Bitboard:
       do
         builder += f(b.lsb)
         b &= (b - 1L)
-      builder.result
+      builder.result()
 
     def iterator: Iterator[Square] = new:
       private var b = a
@@ -251,4 +251,4 @@ object Bitboard:
           builder ++= (if contains(s) then "1" else ".")
           if f != File.H then builder ++= " "
           else if s != Square.H1 then builder ++= "\n"
-      builder.result
+      builder.result()

--- a/core/src/main/scala/Board.scala
+++ b/core/src/main/scala/Board.scala
@@ -257,7 +257,7 @@ case class Board(occupied: Bitboard, byColor: ByColor[Bitboard], byRole: ByRole[
         val piece = color - role
         (c & r).foreach: s =>
           m += s -> piece
-    m.result
+    m.result()
 
   def piecesOf(c: Color): Map[Square, Piece] =
     pieceMap.filter((_, p) => p.color == c)

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -23,6 +23,8 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
 
   export color.white as isWhiteTurn
 
+  def isTurn(c: Color): Boolean = c == color
+
   def withCastles(c: Castles) = updateHistory(_.withCastles(c))
 
   def unary_! : Position = withColor(color = !color)

--- a/core/src/main/scala/format/BinaryFen.scala
+++ b/core/src/main/scala/format/BinaryFen.scala
@@ -13,7 +13,7 @@ case class BinaryFen(value: Array[Byte]) extends AnyVal:
     val reader = new Iterator[Byte]:
       val inner = value.iterator
       override inline def hasNext: Boolean = inner.hasNext
-      override inline def next: Byte = if hasNext then inner.next else 0.toByte
+      override inline def next: Byte = if hasNext then inner.next() else 0.toByte
 
     val occupied = Bitboard(readLong(reader))
 
@@ -92,12 +92,12 @@ case class BinaryFen(value: Array[Byte]) extends AnyVal:
     while it.hasNext
     do
       val (lo, hi) = readNibbles(reader)
-      unpackPiece(it.next, lo)
-      if it.hasNext then unpackPiece(it.next, hi)
+      unpackPiece(it.next(), lo)
+      if it.hasNext then unpackPiece(it.next(), hi)
 
     val halfMoveClock = HalfMoveClock(readLeb128(reader))
     val ply = Ply(readLeb128(reader))
-    val variant = reader.next match
+    val variant = reader.next() match
       case 0 => Standard
       case 1 => Crazyhouse
       case 2 => Chess960
@@ -218,7 +218,7 @@ object BinaryFen:
 
     val it = occupied.iterator
     while it.hasNext
-    do writeNibbles(builder, packPiece(it.next), if it.hasNext then packPiece(it.next) else 0)
+    do writeNibbles(builder, packPiece(it.next()), if it.hasNext then packPiece(it.next()) else 0)
 
     val halfMoveClock = position.history.halfMoveClock.value
     val ply = input.fullMoveNumber.ply(position.color).value
@@ -256,7 +256,7 @@ object BinaryFen:
         writeNibbles(builder, pockets.white.queen, pockets.black.queen)
         if crazyData.promoted.nonEmpty then writeLong(builder, crazyData.promoted.value)
 
-    builder.result
+    builder.result()
 
   object implementation:
 
@@ -271,14 +271,14 @@ object BinaryFen:
       builder.addOne(v.toByte)
 
     def readLong(reader: Iterator[Byte]): Long =
-      ((reader.next & 0xffL) << 56) |
-        ((reader.next & 0xffL) << 48) |
-        ((reader.next & 0xffL) << 40) |
-        ((reader.next & 0xffL) << 32) |
-        ((reader.next & 0xffL) << 24) |
-        ((reader.next & 0xffL) << 16) |
-        ((reader.next & 0xffL) << 8) |
-        (reader.next & 0xffL)
+      ((reader.next() & 0xffL) << 56) |
+        ((reader.next() & 0xffL) << 48) |
+        ((reader.next() & 0xffL) << 40) |
+        ((reader.next() & 0xffL) << 32) |
+        ((reader.next() & 0xffL) << 24) |
+        ((reader.next() & 0xffL) << 16) |
+        ((reader.next() & 0xffL) << 8) |
+        (reader.next() & 0xffL)
 
     def writeLeb128(builder: ArrayBuilder[Byte], v: Int): Unit =
       var n = v
@@ -292,7 +292,7 @@ object BinaryFen:
       var n = 0
       var shift = 0
       while
-        val b = reader.next
+        val b = reader.next()
         n |= (b & 127) << shift
         shift += 7
         (b & 128) != 0
@@ -303,7 +303,7 @@ object BinaryFen:
       builder.addOne((lo | (hi << 4)).toByte)
 
     def readNibbles(reader: Iterator[Byte]): (Int, Int) =
-      val b = reader.next
+      val b = reader.next()
       ((b & 0xf), (b >>> 4) & 0xf)
 
     def minimumUnmovedRooks(position: Position): UnmovedRooks =

--- a/core/src/main/scala/format/FenReader.scala
+++ b/core/src/main/scala/format/FenReader.scala
@@ -184,7 +184,7 @@ trait FenReader:
         rank -= 1
       if rank < 0 then error = Some("too many ranks")
       else
-        iter.next match
+        iter.next() match
           case '/' => // ignored, optional. Rank switch is automatic
           case ch if numberSet.contains(ch) =>
             file += (ch - '0')
@@ -198,7 +198,7 @@ trait FenReader:
                   addPieceAt(p, square)
                   if iter.headOption == Some('~') then
                     promoted |= square
-                    val _ = iter.next
+                    val _ = iter.next()
                 case None => error = Some(s"invalid piece $ch")
             file += 1
     val board = Board(

--- a/core/src/main/scala/variant/Antichess.scala
+++ b/core/src/main/scala/variant/Antichess.scala
@@ -64,38 +64,39 @@ case object Antichess
 
   private def hasInsufficientMaterial(position: Position, color: Color): Boolean =
     (
-       position.onlyKnights &&
-       position.white.count == 1 &&
-       position.black.count == 1 &&
-       position.isTurn(color) != allOnSameColourSquares(position)
+      position.onlyKnights &&
+        position.white.count == 1 &&
+        position.black.count == 1 &&
+        position.isTurn(color) != allOnSameColourSquares(position)
     ) ||
-    {
-      val subject = if position.isTurn(color) then position.us else position.them
-      val opposing = if position.isTurn(color) then position.them else position.us
-      val subjectBishops = subject & position.bishops
-      val subjectPawns = subject & position.pawns
-      val opposingBishops = opposing & position.bishops
-      subjectBishops.nonEmpty &&
-      opposingBishops.nonEmpty &&
-      opposingBishops == opposing &&
-      List(Bitboard.lightSquares, Bitboard.darkSquares).exists(colorComplex =>
-        opposingBishops.isDisjoint(colorComplex) && subjectBishops.intersects(colorComplex)
-      ) &&
-      (
-        subjectPawns.isEmpty || (
-          // todo - handle cases with > 1 subject pawn/opposing bishop that are still
-          // impossible for subject to be win
-          subjectPawns.count == 1 &&
-          opposingBishops.count == 1 &&
-          List(
-            (File.B, Bitboard.lightSquares),
-            (File.G, Bitboard.darkSquares)
-          ).forall: (file, colorComplexForWhite) =>
-            subjectPawns.isDisjoint(Bitboard.file(file)) ||
-            subjectBishops.isDisjoint(if color == Color.White then colorComplexForWhite else ~colorComplexForWhite)
+      {
+        val subject = if position.isTurn(color) then position.us else position.them
+        val opposing = if position.isTurn(color) then position.them else position.us
+        val subjectBishops = subject & position.bishops
+        val subjectPawns = subject & position.pawns
+        val opposingBishops = opposing & position.bishops
+        subjectBishops.nonEmpty &&
+        opposingBishops.nonEmpty &&
+        opposingBishops == opposing &&
+        List(Bitboard.lightSquares, Bitboard.darkSquares).exists(colorComplex =>
+          opposingBishops.isDisjoint(colorComplex) && subjectBishops.intersects(colorComplex)
+        ) &&
+        (
+          subjectPawns.isEmpty || (
+            // todo - handle cases with > 1 subject pawn/opposing bishop that are still
+            // impossible for subject to be win
+            subjectPawns.count == 1 &&
+              opposingBishops.count == 1 &&
+              List(
+                (File.B, Bitboard.lightSquares),
+                (File.G, Bitboard.darkSquares)
+              ).forall: (file, colorComplexForWhite) =>
+                subjectPawns.isDisjoint(Bitboard.file(file)) ||
+                  subjectBishops.isDisjoint(if color == Color.White then colorComplexForWhite
+                  else ~colorComplexForWhite)
+          )
         )
-      )
-    }
+      }
 
   // No player can win if the only remaining pieces are opposing bishops on different coloured
   // diagonals. There may be pawns that are incapable of moving and do not attack the right color

--- a/core/src/main/scala/variant/Antichess.scala
+++ b/core/src/main/scala/variant/Antichess.scala
@@ -83,8 +83,8 @@ case object Antichess
         ) &&
         (
           subjectPawns.isEmpty || (
-            // todo - handle cases with > 1 subject pawn/opposing bishop that are still
-            // impossible for subject to be win
+            // TODO: handle cases with > 1 subject pawn/opposing bishop that are still
+            // impossible for the subject to win.
             subjectPawns.count == 1 &&
               opposingBishops.count == 1 &&
               List(

--- a/core/src/main/scala/variant/Antichess.scala
+++ b/core/src/main/scala/variant/Antichess.scala
@@ -57,10 +57,45 @@ case object Antichess
   // player can win (depending on whose turn it is).
 
   override def opponentHasInsufficientMaterial(position: Position): Boolean =
-    justOneKnightEach(position) && allOnSameColourSquares(position)
+    hasInsufficientMaterial(position, !position.color)
 
   override def playerHasInsufficientMaterial(position: Position): Boolean =
-    justOneKnightEach(position) && !allOnSameColourSquares(position)
+    hasInsufficientMaterial(position, position.color)
+
+  private def hasInsufficientMaterial(position: Position, color: Color): Boolean =
+    (
+       position.onlyKnights &&
+       position.white.count == 1 &&
+       position.black.count == 1 &&
+       position.isTurn(color) != allOnSameColourSquares(position)
+    ) ||
+    {
+      val subject = if position.isTurn(color) then position.us else position.them
+      val opposing = if position.isTurn(color) then position.them else position.us
+      val subjectBishops = subject & position.bishops
+      val subjectPawns = subject & position.pawns
+      val opposingBishops = opposing & position.bishops
+      subjectBishops.nonEmpty &&
+      opposingBishops.nonEmpty &&
+      opposingBishops == opposing &&
+      List(Bitboard.lightSquares, Bitboard.darkSquares).exists(colorComplex =>
+        opposingBishops.isDisjoint(colorComplex) && subjectBishops.intersects(colorComplex)
+      ) &&
+      (
+        subjectPawns.isEmpty || (
+          // todo - handle cases with > 1 subject pawn/opposing bishop that are still
+          // impossible for subject to be win
+          subjectPawns.count == 1 &&
+          opposingBishops.count == 1 &&
+          List(
+            (File.B, Bitboard.lightSquares),
+            (File.G, Bitboard.darkSquares)
+          ).forall: (file, colorComplexForWhite) =>
+            subjectPawns.isDisjoint(Bitboard.file(file)) ||
+            subjectBishops.isDisjoint(if color == Color.White then colorComplexForWhite else ~colorComplexForWhite)
+        )
+      )
+    }
 
   // No player can win if the only remaining pieces are opposing bishops on different coloured
   // diagonals. There may be pawns that are incapable of moving and do not attack the right color
@@ -102,6 +137,3 @@ case object Antichess
   private def allOnSameColourSquares(position: Position): Boolean =
     Bitboard.lightSquares.isDisjoint(position.occupied) ||
       Bitboard.darkSquares.isDisjoint(position.occupied)
-
-  private def justOneKnightEach(position: Position): Boolean =
-    position.onlyKnights && position.white.count == 1 && position.black.count == 1

--- a/core/src/main/scala/variant/Antichess.scala
+++ b/core/src/main/scala/variant/Antichess.scala
@@ -88,12 +88,10 @@ case object Antichess
             subjectPawns.count == 1 &&
               opposingBishops.count == 1 &&
               List(
-                (File.B, Bitboard.lightSquares),
-                (File.G, Bitboard.darkSquares)
-              ).forall: (file, colorComplexForWhite) =>
-                subjectPawns.isDisjoint(Bitboard.file(file)) ||
-                  subjectBishops.isDisjoint(if color == Color.White then colorComplexForWhite
-                  else ~colorComplexForWhite)
+                (File.B, if color == Color.White then Bitboard.darkSquares else Bitboard.lightSquares),
+                (File.G, if color == Color.White then Bitboard.lightSquares else Bitboard.darkSquares)
+              ).forall: (file, colorComplex) =>
+                subjectPawns.isDisjoint(Bitboard.file(file)) || opposingBishops.isDisjoint(colorComplex)
           )
         )
       }

--- a/test-kit/src/test/scala/AntichessVariantTest.scala
+++ b/test-kit/src/test/scala/AntichessVariantTest.scala
@@ -218,8 +218,7 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       "8/7B/8/4b3/8/1p6/8/8 b - - 0 1" -> (Square.E5 -> Square.D4),
       "3b4/8/2B5/2P1b3/8/8/8/8 w - - 0 1" -> (Square.C6 -> Square.A8),
       "8/8/BP6/B5b1/8/8/8/8 w - - 0 1" -> (Square.A6 -> Square.B5),
-      // the following are actually insufficient material, but don't qualify under curr behaviour
-      "8/8/BP6/B6b/8/8/8/8 w - - 0 1" -> (Square.A6 -> Square.B5),
+      // the following is actually insufficient material, but doesn't qualify under curr behaviour
       "8/8/2B5/P1P1b3/8/8/8/8 w - - 0 1" -> (Square.C6 -> Square.A8)
     ).foreach: (fen, move) =>
       val game = fenToGame(FullFen(fen), Antichess)
@@ -236,7 +235,8 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       "6B1/8/6P1/8/5b2/8/8/8 w - - 0 1" -> (Square.G6 -> Square.G7),
       "8/7B/8/8/5b2/6p1/8/8 b - - 0 1" -> (Square.F4 -> Square.E3),
       "8/8/7B/8/6b1/1p6/8/8 b - - 0 1" -> (Square.B3 -> Square.B2),
-      "8/8/2B5/2P1b3/8/8/8/8 w - - 0 1" -> (Square.C6 -> Square.A8)
+      "8/8/2B5/2P1b3/8/8/8/8 w - - 0 1" -> (Square.C6 -> Square.A8),
+      "8/8/BP6/B6b/8/8/8/8 w - - 0 1" -> (Square.A6 -> Square.B5)
     ).foreach: (fen, move) =>
       val game = fenToGame(FullFen(fen), Antichess)
       assert(game.position.playerHasInsufficientMaterial)

--- a/test-kit/src/test/scala/AntichessVariantTest.scala
+++ b/test-kit/src/test/scala/AntichessVariantTest.scala
@@ -199,14 +199,139 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
   ):
     val position = FullFen("1n6/8/8/8/8/4N3/8/8 w - - 0 1")
     val game = fenToGame(position, Antichess).playMoves(Square.E3 -> Square.D1).get
-    assertEquals(game.position.playerHasInsufficientMaterial, true)
+    assert(game.position.playerHasInsufficientMaterial)
 
   test(
     "Player has sufficient material when there are only two remaining knights on same color squares"
   ):
     val position = FullFen("1n6/8/8/8/8/8/8/7N w - - 0 1")
     val game = fenToGame(position, Antichess).playMoves(Square.H1 -> Square.G3).get
-    assertEquals(game.position.playerHasInsufficientMaterial, false)
+    assertNot(game.position.playerHasInsufficientMaterial)
+
+  test(
+    "Side has insufficient material when no pawns and opponent only has opposite-coloured bishops"
+  ):
+    val position = FullFen("6b1/BB6/6b1/6N1/B2K1R2/8/3QK3/1b6 w - - 0 1")
+    val game = fenToGame(position, Antichess)
+    assert(game.position.playerHasInsufficientMaterial)
+    assertNot(game.position.opponentHasInsufficientMaterial)
+    val updated = game.playMoves(Square.G5 -> Square.H7).get
+    assertNot(updated.position.playerHasInsufficientMaterial)
+    assert(updated.position.opponentHasInsufficientMaterial)
+
+  test(
+    "Side has sufficient material when opponent has bishops on both colour complexes"
+  ):
+    val position = FullFen("3b4/1B6/6b1/6N1/3K1R2/8/3QK3/8 w - - 0 1")
+    val game = fenToGame(position, Antichess)
+    assertNot(game.position.playerHasInsufficientMaterial)
+    assertNot(game.position.opponentHasInsufficientMaterial)
+    val updated = game.playMoves(Square.G5 -> Square.H7).get
+    assertNot(updated.position.playerHasInsufficientMaterial)
+    assertNot(updated.position.opponentHasInsufficientMaterial)
+
+  test(
+    "Side has sufficient material when no opposite-coloured bishops"
+  ):
+    val position = FullFen("8/8/8/8/8/3p1b1B/8/8 b - - 0 1")
+    val game = fenToGame(position, Antichess)
+    assertNot(game.position.playerHasInsufficientMaterial)
+    assertNot(game.position.opponentHasInsufficientMaterial)
+    val updated = game.playMoves(Square.D3 -> Square.D2).get
+    assertNot(updated.position.playerHasInsufficientMaterial)
+    assertNot(updated.position.opponentHasInsufficientMaterial)
+
+  test(
+    "Side has sufficient material with knight pawn when bishop is on complex of corner square (opposite-coloured bishops)"
+  ):
+    List(
+      (
+        "8/8/1PB5/4b3/8/8/8/8 w - - 0 1",
+        Square.C6 -> Square.A8
+      ),
+      (
+        "7B/8/6P1/5b2/8/8/8/8 w - - 0 1",
+        Square.G6 -> Square.G7
+      ),
+      (
+        "7B/8/8/5b2/8/6p1/8/8 b - - 0 1",
+        Square.F5 -> Square.E4
+      ),
+      (
+         "8/7B/8/4b3/8/1p6/8/8 b - - 0 1",
+         Square.E5 -> Square.D4
+      )
+    ).foreach: (fen, move) =>
+      val position = FullFen(fen)
+      val game = fenToGame(position, Antichess)
+      assertNot(game.position.playerHasInsufficientMaterial)
+      assertNot(game.position.opponentHasInsufficientMaterial)
+      val updated = game.playMoves(move).get
+      assertNot(updated.position.playerHasInsufficientMaterial)
+      assertNot(updated.position.opponentHasInsufficientMaterial)
+
+  test(
+    "Side has insufficient material with knight pawn when bishop isn't on complex of corner square (opposite-coloured bishops)"
+  ):
+    List(
+      (
+        "8/8/1P6/2B2b2/8/8/8/8 w - - 0 1",
+        Square.C5 -> Square.A3
+      ),
+      (
+        "6B1/8/6P1/8/5b2/8/8/8 w - - 0 1",
+        Square.G6 -> Square.G7
+      ),
+      (
+        "8/7B/8/8/5b2/6p1/8/8 b - - 0 1",
+        Square.F4 -> Square.E3
+      ),
+      (
+         "8/8/7B/8/6b1/1p6/8/8 b - - 0 1",
+         Square.B3 -> Square.B2
+      )
+    ).foreach: (fen, move) =>
+      val position = FullFen(fen)
+      val game = fenToGame(position, Antichess)
+      assert(game.position.playerHasInsufficientMaterial)
+      assertNot(game.position.opponentHasInsufficientMaterial)
+      val updated = game.playMoves(move).get
+      assertNot(updated.position.playerHasInsufficientMaterial)
+      assert(updated.position.opponentHasInsufficientMaterial)
+
+  test(
+    "Side has insufficient material with c-pawn (1 opposite-coloured bishop each)"
+  ):
+    val position = FullFen("8/8/2B5/2P1b3/8/8/8/8 w - - 0 1")
+    val game = fenToGame(position, Antichess)
+    assert(game.position.playerHasInsufficientMaterial)
+    assertNot(game.position.opponentHasInsufficientMaterial)
+    val updated = game.playMoves(Square.C6 -> Square.A8).get
+    assertNot(updated.position.playerHasInsufficientMaterial)
+    assert(updated.position.opponentHasInsufficientMaterial)
+
+  test(
+    "Side has sufficient material with 1 pawn and two bishops for opponent"
+  ):
+    val position = FullFen("3b4/8/2B5/2P1b3/8/8/8/8 w - - 0 1")
+    val game = fenToGame(position, Antichess)
+    assertNot(game.position.playerHasInsufficientMaterial)
+    assertNot(game.position.opponentHasInsufficientMaterial)
+    val updated = game.playMoves(Square.C6 -> Square.A8).get
+    assertNot(updated.position.playerHasInsufficientMaterial)
+    assertNot(updated.position.opponentHasInsufficientMaterial)
+
+  test(
+    "Side has sufficient material with 2 pawns and opposite-coloured bishops"
+  ):
+    // This is actually unwinnable for White, but current behaviour doesn't permit insufficient material.
+    val position = FullFen("8/8/2B5/P1P1b3/8/8/8/8 w - - 0 1")
+    val game = fenToGame(position, Antichess)
+    assertNot(game.position.playerHasInsufficientMaterial)
+    assertNot(game.position.opponentHasInsufficientMaterial)
+    val updated = game.playMoves(Square.C6 -> Square.A8).get
+    assertNot(updated.position.playerHasInsufficientMaterial)
+    assertNot(updated.position.opponentHasInsufficientMaterial)
 
   test("Not be drawn on insufficient mating material"):
     val position = FullFen("4K3/8/1b6/8/8/8/5B2/3k4 b - -")

--- a/test-kit/src/test/scala/AntichessVariantTest.scala
+++ b/test-kit/src/test/scala/AntichessVariantTest.scala
@@ -208,130 +208,39 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
     val game = fenToGame(position, Antichess).playMoves(Square.H1 -> Square.G3).get
     assertNot(game.position.playerHasInsufficientMaterial)
 
-  test(
-    "Side has insufficient material when no pawns and opponent only has opposite-coloured bishops"
-  ):
-    val position = FullFen("6b1/BB6/6b1/6N1/B2K1R2/8/3QK3/1b6 w - - 0 1")
-    val game = fenToGame(position, Antichess)
-    assert(game.position.playerHasInsufficientMaterial)
-    assertNot(game.position.opponentHasInsufficientMaterial)
-    val updated = game.playMoves(Square.G5 -> Square.H7).get
-    assertNot(updated.position.playerHasInsufficientMaterial)
-    assert(updated.position.opponentHasInsufficientMaterial)
-
-  test(
-    "Side has sufficient material when opponent has bishops on both colour complexes"
-  ):
-    val position = FullFen("3b4/1B6/6b1/6N1/3K1R2/8/3QK3/8 w - - 0 1")
-    val game = fenToGame(position, Antichess)
-    assertNot(game.position.playerHasInsufficientMaterial)
-    assertNot(game.position.opponentHasInsufficientMaterial)
-    val updated = game.playMoves(Square.G5 -> Square.H7).get
-    assertNot(updated.position.playerHasInsufficientMaterial)
-    assertNot(updated.position.opponentHasInsufficientMaterial)
-
-  test(
-    "Side has sufficient material when no opposite-coloured bishops"
-  ):
-    val position = FullFen("8/8/8/8/8/3p1b1B/8/8 b - - 0 1")
-    val game = fenToGame(position, Antichess)
-    assertNot(game.position.playerHasInsufficientMaterial)
-    assertNot(game.position.opponentHasInsufficientMaterial)
-    val updated = game.playMoves(Square.D3 -> Square.D2).get
-    assertNot(updated.position.playerHasInsufficientMaterial)
-    assertNot(updated.position.opponentHasInsufficientMaterial)
-
-  test(
-    "Side has sufficient material with knight pawn when bishop is on complex of corner square (opposite-coloured bishops)"
-  ):
+  test("Side has sufficient material - bishops"):
     List(
-      (
-        "8/8/1PB5/4b3/8/8/8/8 w - - 0 1",
-        Square.C6 -> Square.A8
-      ),
-      (
-        "7B/8/6P1/5b2/8/8/8/8 w - - 0 1",
-        Square.G6 -> Square.G7
-      ),
-      (
-        "7B/8/8/5b2/8/6p1/8/8 b - - 0 1",
-        Square.F5 -> Square.E4
-      ),
-      (
-         "8/7B/8/4b3/8/1p6/8/8 b - - 0 1",
-         Square.E5 -> Square.D4
-      )
+      "3b4/1B6/6b1/6N1/3K1R2/8/3QK3/8 w - - 0 1" -> (Square.G5 -> Square.H7),
+      "8/8/8/8/8/3p1b1B/8/8 b - - 0 1" -> (Square.D3 -> Square.D2),
+      "8/8/1PB5/4b3/8/8/8/8 w - - 0 1" -> (Square.C6 -> Square.A8),
+      "7B/8/6P1/5b2/8/8/8/8 w - - 0 1" -> (Square.G6 -> Square.G7),
+      "7B/8/8/5b2/8/6p1/8/8 b - - 0 1" -> (Square.F5 -> Square.E4),
+      "8/7B/8/4b3/8/1p6/8/8 b - - 0 1" -> (Square.E5 -> Square.D4),
+      "3b4/8/2B5/2P1b3/8/8/8/8 w - - 0 1" -> (Square.C6 -> Square.A8),
+      "8/8/2B5/P1P1b3/8/8/8/8 w - - 0 1" -> (Square.C6 -> Square.A8)
     ).foreach: (fen, move) =>
-      val position = FullFen(fen)
-      val game = fenToGame(position, Antichess)
+      val game = fenToGame(FullFen(fen), Antichess)
       assertNot(game.position.playerHasInsufficientMaterial)
       assertNot(game.position.opponentHasInsufficientMaterial)
       val updated = game.playMoves(move).get
       assertNot(updated.position.playerHasInsufficientMaterial)
       assertNot(updated.position.opponentHasInsufficientMaterial)
 
-  test(
-    "Side has insufficient material with knight pawn when bishop isn't on complex of corner square (opposite-coloured bishops)"
-  ):
+  test("Side has insufficient material - bishops"):
     List(
-      (
-        "8/8/1P6/2B2b2/8/8/8/8 w - - 0 1",
-        Square.C5 -> Square.A3
-      ),
-      (
-        "6B1/8/6P1/8/5b2/8/8/8 w - - 0 1",
-        Square.G6 -> Square.G7
-      ),
-      (
-        "8/7B/8/8/5b2/6p1/8/8 b - - 0 1",
-        Square.F4 -> Square.E3
-      ),
-      (
-         "8/8/7B/8/6b1/1p6/8/8 b - - 0 1",
-         Square.B3 -> Square.B2
-      )
+      "6b1/BB6/6b1/6N1/B2K1R2/8/3QK3/1b6 w - - 0 1" -> (Square.G5 -> Square.H7),
+      "8/8/1P6/2B2b2/8/8/8/8 w - - 0 1" -> (Square.C5 -> Square.A3),
+      "6B1/8/6P1/8/5b2/8/8/8 w - - 0 1" -> (Square.G6 -> Square.G7),
+      "8/7B/8/8/5b2/6p1/8/8 b - - 0 1" -> (Square.F4 -> Square.E3),
+      "8/8/7B/8/6b1/1p6/8/8 b - - 0 1" -> (Square.B3 -> Square.B2),
+      "8/8/2B5/2P1b3/8/8/8/8 w - - 0 1" -> (Square.C6 -> Square.A8)
     ).foreach: (fen, move) =>
-      val position = FullFen(fen)
-      val game = fenToGame(position, Antichess)
+      val game = fenToGame(FullFen(fen), Antichess)
       assert(game.position.playerHasInsufficientMaterial)
       assertNot(game.position.opponentHasInsufficientMaterial)
       val updated = game.playMoves(move).get
       assertNot(updated.position.playerHasInsufficientMaterial)
       assert(updated.position.opponentHasInsufficientMaterial)
-
-  test(
-    "Side has insufficient material with c-pawn (1 opposite-coloured bishop each)"
-  ):
-    val position = FullFen("8/8/2B5/2P1b3/8/8/8/8 w - - 0 1")
-    val game = fenToGame(position, Antichess)
-    assert(game.position.playerHasInsufficientMaterial)
-    assertNot(game.position.opponentHasInsufficientMaterial)
-    val updated = game.playMoves(Square.C6 -> Square.A8).get
-    assertNot(updated.position.playerHasInsufficientMaterial)
-    assert(updated.position.opponentHasInsufficientMaterial)
-
-  test(
-    "Side has sufficient material with 1 pawn and two bishops for opponent"
-  ):
-    val position = FullFen("3b4/8/2B5/2P1b3/8/8/8/8 w - - 0 1")
-    val game = fenToGame(position, Antichess)
-    assertNot(game.position.playerHasInsufficientMaterial)
-    assertNot(game.position.opponentHasInsufficientMaterial)
-    val updated = game.playMoves(Square.C6 -> Square.A8).get
-    assertNot(updated.position.playerHasInsufficientMaterial)
-    assertNot(updated.position.opponentHasInsufficientMaterial)
-
-  test(
-    "Side has sufficient material with 2 pawns and opposite-coloured bishops"
-  ):
-    // This is actually unwinnable for White, but current behaviour doesn't permit insufficient material.
-    val position = FullFen("8/8/2B5/P1P1b3/8/8/8/8 w - - 0 1")
-    val game = fenToGame(position, Antichess)
-    assertNot(game.position.playerHasInsufficientMaterial)
-    assertNot(game.position.opponentHasInsufficientMaterial)
-    val updated = game.playMoves(Square.C6 -> Square.A8).get
-    assertNot(updated.position.playerHasInsufficientMaterial)
-    assertNot(updated.position.opponentHasInsufficientMaterial)
 
   test("Not be drawn on insufficient mating material"):
     val position = FullFen("4K3/8/1b6/8/8/8/5B2/3k4 b - -")

--- a/test-kit/src/test/scala/AntichessVariantTest.scala
+++ b/test-kit/src/test/scala/AntichessVariantTest.scala
@@ -217,6 +217,9 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       "7B/8/8/5b2/8/6p1/8/8 b - - 0 1" -> (Square.F5 -> Square.E4),
       "8/7B/8/4b3/8/1p6/8/8 b - - 0 1" -> (Square.E5 -> Square.D4),
       "3b4/8/2B5/2P1b3/8/8/8/8 w - - 0 1" -> (Square.C6 -> Square.A8),
+      "8/8/BP6/B5b1/8/8/8/8 w - - 0 1" -> (Square.A6 -> Square.B5),
+      // the following are actually insufficient material, but don't qualify under curr behaviour
+      "8/8/BP6/B6b/8/8/8/8 w - - 0 1" -> (Square.A6 -> Square.B5),
       "8/8/2B5/P1P1b3/8/8/8/8 w - - 0 1" -> (Square.C6 -> Square.A8)
     ).foreach: (fen, move) =>
       val game = fenToGame(FullFen(fen), Antichess)

--- a/test-kit/src/test/scala/format/BinaryFenTest.scala
+++ b/test-kit/src/test/scala/format/BinaryFenTest.scala
@@ -14,13 +14,13 @@ class BinaryFenTest extends ScalaCheckSuite:
     forAll: (v: Long) =>
       val builder = ArrayBuilder.ofByte()
       BinaryFen.implementation.writeLong(builder, v)
-      assertEquals(BinaryFen.implementation.readLong(builder.result.iterator), v)
+      assertEquals(BinaryFen.implementation.readLong(builder.result().iterator), v)
 
   test("leb128 roundtrip"):
     forAll(Gen.posNum[Int]): (v: Int) =>
       val builder = ArrayBuilder.ofByte()
       BinaryFen.implementation.writeLeb128(builder, v)
-      assertEquals(BinaryFen.implementation.readLeb128(builder.result.iterator), v)
+      assertEquals(BinaryFen.implementation.readLeb128(builder.result().iterator), v)
 
   private val genNibble = Gen.chooseNum[Int](0, 15)
 
@@ -28,7 +28,7 @@ class BinaryFenTest extends ScalaCheckSuite:
     forAll(genNibble, genNibble): (lo: Int, hi: Int) =>
       val builder = ArrayBuilder.ofByte()
       BinaryFen.implementation.writeNibbles(builder, lo, hi)
-      assertEquals(BinaryFen.implementation.readNibbles(builder.result.iterator), (lo, hi))
+      assertEquals(BinaryFen.implementation.readNibbles(builder.result().iterator), (lo, hi))
 
   test("rewrite fixpoint"):
     forAll: (bytes: Array[Byte]) =>


### PR DESCRIPTION
Closes https://github.com/lichess-org/lila/issues/12966.

If side A has a bishop on colour complex X, and side B only has bishop(s) (and only on colour complex Y), then after ruling out certain stalemate constructions, we can conclude it's insufficient material for side A. I.e.:
- If side A has no pawns, stalemate is impossible.
- Or if side A only has one pawn (that's not a knight pawn that can allow the bishop to be stalemated in the corner, [e.g.](https://github.com/lichess-org/lila/issues/12966#issuecomment-1585713158)), and side B only has one bishop (preventing the pawn from changing files via a capture), stalemates are also impossible.