### PR TITLE
Attacks: make table init @static to fix init-order NPE

### DIFF
--- a/core/src/main/scala/bitboard/Attacks.scala
+++ b/core/src/main/scala/bitboard/Attacks.scala
@@ -1,7 +1,7 @@
 package chess
 package bitboard
 
-import scala.annotation.static
+import scala.annotation.{ static, unused }
 
 class Attacks
 object Attacks:
@@ -100,7 +100,13 @@ object Attacks:
             (1L << a) | (1L << b) | slidingAttacks(a, 0, BISHOP_DELTAS) & slidingAttacks(b, 0, BISHOP_DELTAS)
     yield ()
 
-  val _ = initialize()
+  // Must be @static so it runs inside the class `<clinit>` *after* the @static
+  // array fields above are assigned. As a plain module field it lands in the
+  // `Attacks$` constructor, whose ordering vs. the static field init is not
+  // guaranteed — observed as `RANKS == null` during initialize() (NPE) depending
+  // on which class triggers `Attacks` loading first.
+  @static @unused
+  private val initialized: Unit = initialize()
 
   extension (l: Long)
     private def contains(s: Int): Boolean =


### PR DESCRIPTION
The attack tables (RANKS, FILES, KING_ATTACKS, ...) are @static fields,
so they are assigned in the Attacks class `<clinit>`. The eager
`val _ = initialize()` that populates them was a plain module field, so
it compiled into the Attacks$ module constructor instead. Across those
two separate initializers the JVM does not guarantee that the static
array fields are assigned before initialize() runs.

initialize()'s first statement is `RANKS(i) = ...`, so if the module
constructor runs before the class `<clinit>` completes, RANKS is still
null and initialization fails with:

  ExceptionInInitializerError
  Caused by: NullPointerException: Cannot store to long array because
             "chess.bitboard.Attacks.RANKS" is null

Which initializer runs first depends on whether the Attacks class or the
Attacks$ module is touched first, which in turn depends on the
move-generation entry path. The favorable order held until the
CastlingRights merge rewired that path, surfacing the latent bug (seen
when running PerftBench: antichess/racingkings crashed on the first
warmup iteration).

Marking the initializer @static moves the initialize() call into the
class `<clinit>`, after the array assignments, so the JVM's in-order
`<clinit>` execution guarantees the tables exist before they are filled.
