### PR TITLE
Improve stack safety for some of Node's functions

### DIFF
--- a/core/src/main/scala/Node.scala
+++ b/core/src/main/scala/Node.scala
@@ -344,8 +344,16 @@ final case class Node[A](
         case Some(c) => c.findInMainline(predicate)
 
   def modifyInMainline(predicate: A => Boolean, f: Node[A] => Node[A]): Option[Node[A]] =
-    if predicate(value) then f(this).some
-    else child.flatMap(_.modifyInMainline(predicate, f)).map(c => withChild(c.some))
+    @tailrec
+    def loop(node: Node[A], acc: List[Node[A]]): Option[Node[A]] =
+      if predicate(node.value) then
+        // f's result replaces the whole subtree here; ancestors fold back on top
+        acc.foldLeft(f(node).some)((child, ancestor) => ancestor.withChild(child).some)
+      else
+        node.child match
+          case None => none // no mainline node matches the predicate
+          case Some(child) => loop(child, node.withoutChild :: acc)
+    loop(this, Nil)
 
   def modifyInMainline(f: A => A): Node[A] =
     copy(value = f(value), child = child.map(_.modifyInMainline(f)))

--- a/core/src/main/scala/Node.scala
+++ b/core/src/main/scala/Node.scala
@@ -351,9 +351,15 @@ final case class Node[A](
     copy(value = f(value), child = child.map(_.modifyInMainline(f)))
 
   def modifyInMainlineAt(n: Int, f: Node[A] => Node[A]): Option[Node[A]] =
-    if n < 0 || n >= mainline.size then none
-    else if n == 0 then f(this).some
-    else child.flatMap(_.modifyInMainlineAt(n - 1, f)).map(c => withChild(c.some))
+    @tailrec
+    def loop(n: Int, node: Node[A], acc: List[Node[A]]): Option[Node[A]] =
+      if n == 0 then
+        acc.foldLeft(f(node).some)((child, ancestor) => ancestor.withChild(child).some)
+      else
+        node.child match
+          case None => none // n points past the end of the mainline
+          case Some(child) => loop(n - 1, child, node.withoutChild :: acc)
+    if n < 0 then none else loop(n, this, Nil)
 
   /**
       * get node at nth in mainline

--- a/core/src/main/scala/Node.scala
+++ b/core/src/main/scala/Node.scala
@@ -353,8 +353,7 @@ final case class Node[A](
   def modifyInMainlineAt(n: Int, f: Node[A] => Node[A]): Option[Node[A]] =
     @tailrec
     def loop(n: Int, node: Node[A], acc: List[Node[A]]): Option[Node[A]] =
-      if n == 0 then
-        acc.foldLeft(f(node).some)((child, ancestor) => ancestor.withChild(child).some)
+      if n == 0 then acc.foldLeft(f(node).some)((child, ancestor) => ancestor.withChild(child).some)
       else
         node.child match
           case None => none // n points past the end of the mainline
@@ -369,7 +368,7 @@ final case class Node[A](
       */
   @tailrec
   def getMainlineNodeAt(n: Int): Option[Node[A]] =
-    if n < 0 || n >= mainline.size then none
+    if n < 0 then none
     else if n == 0 then this.some
     else
       child.match

--- a/core/src/main/scala/Node.scala
+++ b/core/src/main/scala/Node.scala
@@ -356,7 +356,14 @@ final case class Node[A](
     loop(this, Nil)
 
   def modifyInMainline(f: A => A): Node[A] =
-    copy(value = f(value), child = child.map(_.modifyInMainline(f)))
+    @tailrec
+    def loop(node: Node[A], acc: List[Node[A]]): List[Node[A]] =
+      val updated = node.updateValue(f)
+      node.child match
+        case None => updated :: acc
+        case Some(child) => loop(child, updated.withoutChild :: acc)
+    // every spine node keeps its variations; only value and child change
+    Tree.buildReverse(loop(this, Nil)).getOrElse(this)
 
   def modifyInMainlineAt(n: Int, f: Node[A] => Node[A]): Option[Node[A]] =
     @tailrec

--- a/test-kit/src/test/scala/NodeTest.scala
+++ b/test-kit/src/test/scala/NodeTest.scala
@@ -223,6 +223,11 @@ class NodeTest extends ScalaCheckSuite:
     val output = deep.modifyInMainlineAt(depth - 1, _.updateValue(_ + 1)).get
     output.mainlineValues == (0 until depth).map(i => if i == depth - 1 then i + 1 else i).toList
 
+  test("mainline-walking methods are stack-safe on a deep mainline"):
+    val depth = 1_000_000
+    val deep = Tree.build(0 until depth).get
+    assert(deep.getMainlineNodeAt(depth - 1).exists(_.value == depth - 1))
+
   test("clearVariations.size == mainline.size"):
     forAll: (node: Node[Int]) =>
       node.clearVariations.size == node.mainline.size

--- a/test-kit/src/test/scala/NodeTest.scala
+++ b/test-kit/src/test/scala/NodeTest.scala
@@ -212,7 +212,6 @@ class NodeTest extends ScalaCheckSuite:
       val output = node.modifyInMainlineAt(n, _ => newNode)
       n >= node.mainline.size || output.flatMap(_.take(n)) == node.take(n)
 
-  override def scalaCheckInitialSeed = "z_ejR8Ve8lZWkWpnrN7gBGfK1bta0yof-THAkg8qgjK="
   test("modifyInMainlineAt(n)(node) . get(n) == node"):
     forAll: (node: Node[Int], newNode: Node[Int]) =>
       val n = Random.nextInt(node.mainline.size)

--- a/test-kit/src/test/scala/NodeTest.scala
+++ b/test-kit/src/test/scala/NodeTest.scala
@@ -217,6 +217,12 @@ class NodeTest extends ScalaCheckSuite:
       val n = Random.nextInt(node.mainline.size)
       node.modifyInMainlineAt(n, _ => newNode).get.getMainlineNodeAt(n) == newNode.some
 
+  test("modifyInMainlineAt is stack-safe and preserves ancestors on a deep mainline"):
+    val depth = 1_000_000
+    val deep = Tree.build(0 until depth).get
+    val output = deep.modifyInMainlineAt(depth - 1, _.updateValue(_ + 1)).get
+    output.mainlineValues == (0 until depth).map(i => if i == depth - 1 then i + 1 else i).toList
+
   test("clearVariations.size == mainline.size"):
     forAll: (node: Node[Int]) =>
       node.clearVariations.size == node.mainline.size

--- a/test-kit/src/test/scala/NodeTest.scala
+++ b/test-kit/src/test/scala/NodeTest.scala
@@ -233,6 +233,7 @@ class NodeTest extends ScalaCheckSuite:
         .flatMap(_.getMainlineNodeAt(depth - 1))
         .exists(_.value == depth)
     )
+    assertEquals(deep.modifyInMainline(_ + 1).mainlineValues, (1 to depth).toList)
 
   test("clearVariations.size == mainline.size"):
     forAll: (node: Node[Int]) =>

--- a/test-kit/src/test/scala/NodeTest.scala
+++ b/test-kit/src/test/scala/NodeTest.scala
@@ -227,6 +227,12 @@ class NodeTest extends ScalaCheckSuite:
     val depth = 1_000_000
     val deep = Tree.build(0 until depth).get
     assert(deep.getMainlineNodeAt(depth - 1).exists(_.value == depth - 1))
+    assert(
+      deep
+        .modifyInMainline(_ == depth - 1, _.updateValue(_ + 1))
+        .flatMap(_.getMainlineNodeAt(depth - 1))
+        .exists(_.value == depth)
+    )
 
   test("clearVariations.size == mainline.size"):
     forAll: (node: Node[Int]) =>


### PR DESCRIPTION
- **Remove wrongly hard coded seed for NodeTest**
- **Make Node.modifyInMainlineAt tail recursive**
- **Fix O(depth²) in getMainlineNodeAt**
- **Make modifyInMainline(predicate, f) stack-safe**
- **Make modifyInMainline(f: A => A) stack-safe**
