### PR TITLE
Force jitpack to download and use sbt 2.0.0

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,6 @@
 jdk:
   - openjdk21
+before_install:
+  - wget -O sbt.jar https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/2.0.0/sbt-launch-2.0.0.jar
+install:
+  - java -Xms2048m -Xmx2048m -XX:ReservedCodeCacheSize=512m -jar sbt.jar -Dsbt.log.noformat=true 'clean; publishM2'


### PR DESCRIPTION
jitpack failed with sbt 2: https://github.com/jitpack/jitpack.io/issues/7993

this also fixes the sbt publish command. The default command is `sbt
clean publishM2` which doesn't work for sbt 2 any more, we need to fix
it with sbt `clean; publishM2`.
